### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/socketio4j/netty-socketio/security/code-scanning/1](https://github.com/socketio4j/netty-socketio/security/code-scanning/1)

To fix this issue, add a `permissions` block that explicitly restricts the permissions for the generated GITHUB_TOKEN. The best and minimal permissions to build Java code and use actions/checkout are `contents: read`. This block can be added at the root of the workflow (applies to all jobs/subsequent jobs by default) or under the specific job (here, `build`) if you want different permissions for other jobs.  
The modification is to add:

```yaml
permissions:
  contents: read
```

directly under the `name:` block, before the `on:` block (root-level), in the `.github/workflows/build.yml` workflow file. No new imports, methods, or any additional definitions are needed for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to enhance security and access controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->