### PR TITLE
Use ctx.fireChannelRead and reorder packet handler

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
@@ -186,14 +186,14 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
             pipeline.addLast(HTTP_COMPRESSION, new HttpContentCompressor());
         }
 
-        pipeline.addLast(PACKET_HANDLER, packetHandler);
-
         pipeline.addLast(AUTHORIZE_HANDLER, authorizeHandler);
         pipeline.addLast(XHR_POLLING_TRANSPORT, xhrPollingTransport);
         if (configuration.isWebsocketCompression()) {
             pipeline.addLast(WEB_SOCKET_TRANSPORT_COMPRESSION, new WebSocketServerCompressionHandler());
         }
         pipeline.addLast(WEB_SOCKET_TRANSPORT, webSocketTransport);
+        
+        pipeline.addLast(PACKET_HANDLER, packetHandler);
 
         pipeline.addLast(SOCKETIO_ENCODER, encoderHandler);
 

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/transport/PollingTransport.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/transport/PollingTransport.java
@@ -172,7 +172,7 @@ public class PollingTransport extends ChannelInboundHandlerAdapter {
             content = decoder.preprocessJson(jsonIndex, content);
         }
 
-        ctx.pipeline().fireChannelRead(new PacketsMessage(client, content, Transport.POLLING));
+        ctx.fireChannelRead(new PacketsMessage(client, content, Transport.POLLING));
     }
 
     protected void onGet(UUID sessionId, ChannelHandlerContext ctx, String origin) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/transport/WebSocketTransport.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/transport/WebSocketTransport.java
@@ -97,7 +97,7 @@ public class WebSocketTransport extends ChannelInboundHandlerAdapter {
             // Retain its content since we pass it further down the pipeline.
             PacketsMessage packetsMessage = new PacketsMessage(client, frame.content().retain(), Transport.WEBSOCKET);
             try {
-                ctx.pipeline().fireChannelRead(packetsMessage);
+                ctx.fireChannelRead(packetsMessage);
             } finally {
                 frame.release();
             }


### PR DESCRIPTION
Replace pipeline.fireChannelRead(...) with ctx.fireChannelRead(...) in PollingTransport and WebSocketTransport so events are propagated from the current handler context (next handler) instead of from the pipeline head. Move PACKET_HANDLER registration in SocketIOChannelInitializer to after the transport handlers (but before the encoder) to ensure correct handler ordering and avoid double-processing. Changes affect SocketIOChannelInitializer.java, PollingTransport.java, and WebSocketTransport.java.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #(issue number)

## Changes Made

- 
- 
- 

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [ ] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

Any additional information, screenshots, or context that reviewers should know.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Netty pipeline message propagation and handler ordering to improve message flow efficiency through transport handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->