### PR TITLE
fix(ssl): fix tls version for default

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
@@ -226,7 +226,7 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
 
         SslContextBuilder builder = SslContextBuilder.forServer(kmf).sslProvider(sslProvider);
         String sslProtocol = socketSslConfig.getSSLProtocol();
-        if (socketSslConfig.isSslProtocolExplicitlySet() && sslProtocol != null) {
+        if (socketSslConfig.isSSLProtocolExplicitlySet() && sslProtocol != null) {
             // SocketSslConfig historically accepted SSLContext algorithm names like "TLS".
             // SslContextBuilder.protocols(...) expects concrete enabled protocol versions.
             if (isTlsProtocolVersion(sslProtocol)) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
@@ -226,7 +226,7 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
 
         SslContextBuilder builder = SslContextBuilder.forServer(kmf).sslProvider(sslProvider);
         String sslProtocol = socketSslConfig.getSSLProtocol();
-        if (sslProtocol != null) {
+        if (socketSslConfig.isSslProtocolExplicitlySet() && sslProtocol != null) {
             // SocketSslConfig historically accepted SSLContext algorithm names like "TLS".
             // SslContextBuilder.protocols(...) expects concrete enabled protocol versions.
             if (isTlsProtocolVersion(sslProtocol)) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketSslConfig.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketSslConfig.java
@@ -201,11 +201,14 @@ public class SocketSslConfig {
     /**
      * Whether {@link #setSSLProtocol(String)} has been called.
      * <p>
-     * This allows the server to distinguish between a default value and an explicit configuration,
-     * so modern JSSE defaults (TLSv1.2/1.3) can be used when the user didn't request a specific version.
+     * This flag is driven purely by invocation, not by the semantic intent of the value. Integrations that
+     * populate {@link SocketSslConfig} programmatically (e.g., factories, recorders, property binders)
+     * should avoid calling {@link #setSSLProtocol(String)} unless they intentionally want to pin the enabled
+     * TLS protocol version via {@code SslContextBuilder.protocols(...)}. When not explicitly set, the server
+     * will rely on the provider defaults (typically TLSv1.2/1.3 on modern JSSE).
      * </p>
      */
-    public boolean isSslProtocolExplicitlySet() {
+    public boolean isSSLProtocolExplicitlySet() {
         return sslProtocolExplicitlySet;
     }
 }

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketSslConfig.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketSslConfig.java
@@ -24,6 +24,7 @@ import javax.net.ssl.KeyManagerFactory;
 
 public class SocketSslConfig {
     private String sslProtocol = "TLSv1";
+    private boolean sslProtocolExplicitlySet;
 
     private String keyStoreFormat = "JKS";
     private InputStream keyStore;
@@ -190,9 +191,21 @@ public class SocketSslConfig {
      */
     public void setSSLProtocol(String sslProtocol) {
         this.sslProtocol = sslProtocol;
+        this.sslProtocolExplicitlySet = true;
     }
 
     public String getSSLProtocol() {
         return sslProtocol;
+    }
+
+    /**
+     * Whether {@link #setSSLProtocol(String)} has been called.
+     * <p>
+     * This allows the server to distinguish between a default value and an explicit configuration,
+     * so modern JSSE defaults (TLSv1.2/1.3) can be used when the user didn't request a specific version.
+     * </p>
+     */
+    public boolean isSslProtocolExplicitlySet() {
+        return sslProtocolExplicitlySet;
     }
 }

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/transport/SocketIoJavaClientSslTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/transport/SocketIoJavaClientSslTest.java
@@ -142,6 +142,85 @@ public class SocketIoJavaClientSslTest {
         }
     }
 
+    @Test
+    public void shouldHandshakeOverWssWhenSslProtocolNotExplicitlyConfigured() throws Exception {
+        CountDownLatch serverReceivedHello = new CountDownLatch(1);
+        CountDownLatch clientReceivedAck = new CountDownLatch(1);
+        CountDownLatch engineHandshakeDone = new CountDownLatch(1);
+        AtomicReference<Throwable> connectError = new AtomicReference<>();
+
+        server = startServer(0, testSslConfigWithoutExplicitProtocol(), serverReceivedHello);
+        int port = awaitBoundPort(server);
+        assertTrue(port > 0, "server did not bind an ephemeral port");
+
+        X509TrustManager trustAll = new X509TrustManager() {
+            @Override
+            public void checkClientTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public void checkServerTrusted(X509Certificate[] chain, String authType) {
+            }
+
+            @Override
+            public X509Certificate[] getAcceptedIssuers() {
+                return new X509Certificate[0];
+            }
+        };
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[] { trustAll }, new SecureRandom());
+
+        OkHttpClient okHttp = new OkHttpClient.Builder()
+                .sslSocketFactory(sslContext.getSocketFactory(), trustAll)
+                .hostnameVerifier((hostname, session) -> true)
+                .readTimeout(1, TimeUnit.MINUTES)
+                .build();
+
+        IO.Options opts = new IO.Options();
+        opts.forceNew = true;
+        opts.reconnection = false;
+        opts.transports = new String[] { "websocket" };
+        opts.webSocketFactory = okHttp;
+        opts.callFactory = okHttp;
+
+        Socket socket = IO.socket("https://127.0.0.1:" + port, opts);
+        try {
+            socket.on(Socket.EVENT_CONNECT_ERROR, args -> {
+                Object first = args.length > 0 ? args[0] : null;
+                if (first instanceof Throwable) {
+                    connectError.set((Throwable) first);
+                } else {
+                    connectError.set(new IllegalStateException(String.valueOf(first)));
+                }
+                engineHandshakeDone.countDown();
+            });
+            socket.on(Socket.EVENT_CONNECT, args -> {
+                try {
+                    JSONObject payload = new JSONObject();
+                    payload.put("a", 1);
+                    socket.emit("hello", payload, (Ack) ackArgs -> {
+                        if (ackArgs.length > 0 && "ok".equals(String.valueOf(ackArgs[0]))) {
+                            clientReceivedAck.countDown();
+                        }
+                    });
+                } catch (Exception e) {
+                    connectError.set(e);
+                } finally {
+                    engineHandshakeDone.countDown();
+                }
+            });
+            socket.connect();
+
+            assertTrue(engineHandshakeDone.await(20, TimeUnit.SECONDS),
+                    () -> "Engine.IO handshake did not complete: " + connectError.get());
+            assertNull(connectError.get(), () -> "connect_error: " + connectError.get());
+            assertTrue(serverReceivedHello.await(15, TimeUnit.SECONDS), "server did not receive hello event");
+            assertTrue(clientReceivedAck.await(15, TimeUnit.SECONDS), "client did not receive ack");
+        } finally {
+            socket.disconnect();
+        }
+    }
+
     /**
      * Exercises polling first (POST body via {@code PollingTransport.onPost}), then upgrade to WebSocket.
      * Server pushes an event right after connect so delivery runs while the client may still be on polling.
@@ -447,6 +526,18 @@ public class SocketIoJavaClientSslTest {
     private SocketSslConfig testSslConfig() throws Exception {
         SocketSslConfig ssl = new SocketSslConfig();
         ssl.setSSLProtocol("TLSv1.2");
+        ssl.setKeyStoreFormat("PKCS12");
+        ssl.setKeyStorePassword("password");
+
+        InputStream ks = SocketIoJavaClientSslTest.class.getClassLoader()
+                .getResourceAsStream("ssl/test-socketio.p12");
+        assertNotNull(ks, "Missing test keystore resource ssl/test-socketio.p12");
+        ssl.setKeyStore(ks);
+        return ssl;
+    }
+
+    private SocketSslConfig testSslConfigWithoutExplicitProtocol() throws Exception {
+        SocketSslConfig ssl = new SocketSslConfig();
         ssl.setKeyStoreFormat("PKCS12");
         ssl.setKeyStorePassword("password");
 


### PR DESCRIPTION
## Description



Fix WSS handshake failures on modern JDKs (e.g., Java 17 on Windows) caused by unintentionally forcing `TLSv1` as the only enabled protocol when `sslProtocol` was not explicitly configured. The server now uses provider defaults (typically TLSv1.2/1.3) unless the user explicitly sets a concrete TLS version.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #160

## Changes Made

- Use a new `SocketSslConfig.isSslProtocolExplicitlySet()` flag so `SslContextBuilder.protocols(...)` is only applied when `setSSLProtocol(...)` was explicitly called.
- Prevent default `sslProtocol="TLSv1"` from restricting enabled protocols when the user did not configure a specific version.
- Add a new WSS test that omits `setSSLProtocol(...)` and verifies the Java client can connect and exchange an event/ack.

## Testing

- [x] All existing tests pass
- [x] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [x] Integration tests pass (if applicable)

## Checklist

- [x] Code follows project coding standards
- [x] Self-review completed
- [x] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [x] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

- The previous behavior could lead to `SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)` on Java 17+ environments where `TLSv1` is disabled by default.
- Users who need to pin a specific TLS version (e.g., `TLSv1.2`) can still do so via `SocketSslConfig.setSSLProtocol("TLSv1.2")`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSL/HTTPS connection handling to intelligently use provider default protocols when explicit protocol configuration is not specified.

* **Tests**
  * Added test coverage for SSL handshake scenarios without explicit protocol configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->