### PR TITLE
Bump Netty to 4.2.12.Final

### DIFF
--- a/netty-socketio-examples/netty-socketio-core-example/pom.xml
+++ b/netty-socketio-examples/netty-socketio-core-example/pom.xml
@@ -17,7 +17,7 @@
     <properties>
         <micrometer.version>1.16.1</micrometer.version>
         <hll.version>1.6.0</hll.version>
-        <netty.version>4.2.9.Final</netty.version>
+        <netty.version>4.2.12.Final</netty.version>
         <jackson.version>2.20.1</jackson.version>
     </properties>
 

--- a/netty-socketio-examples/netty-socketio-examples-spring-boot-base/pom.xml
+++ b/netty-socketio-examples/netty-socketio-examples-spring-boot-base/pom.xml
@@ -15,7 +15,7 @@
   <description>NettySocketIO Spring Boot Examples</description>
 
   <properties>
-    <netty.version>4.2.9.Final</netty.version>
+    <netty.version>4.2.12.Final</netty.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <testcontainers.version>2.0.3</testcontainers.version>
-    <netty.version>4.2.9.Final</netty.version>
+    <netty.version>4.2.12.Final</netty.version>
     <netty.tcnative.version>2.0.74.Final</netty.tcnative.version>
     <jmockit.version>1.50</jmockit.version>
     <byte-buddy.version>1.18.4</byte-buddy.version>


### PR DESCRIPTION
Update netty.version from 4.2.9.Final to 4.2.12.Final in the root pom and in example module poms (netty-socketio-core-example and netty-socketio-examples-spring-boot-base) to align Netty versions across the project.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #(issue number)

## Changes Made

- 
- 
- 

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [ ] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

Any additional information, screenshots, or context that reviewers should know.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core networking dependencies to the latest stable release, bringing performance improvements and stability enhancements across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->