### PR TITLE
Potential fix for 1 code quality finding

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -77,10 +77,7 @@ public class PacketDecoder {
                 if (content.getByte(ri) == (byte) 'd' && content.getByte(ri + 1) == (byte) '=') {
                     content.readerIndex(ri + 2);
                 } else {
-                    byte b0 = content.getByte(ri);
-                    byte b1 = content.getByte(ri + 1);
-                    String received = String.format("0x%02X 0x%02X", b0, b1);
-                    throw new IllegalArgumentException("Invalid JSONP format: missing 'd=' prefix, got bytes: " + received);
+                    throw new IllegalArgumentException("Invalid JSONP format: missing 'd=' prefix, got bytes: " + String.format("0x%02X 0x%02X", content.getByte(ri), content.getByte(ri + 1)));
                 }
             }
         }

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -78,7 +78,7 @@ public class PacketDecoder {
                     content.readerIndex(ri + 2);
                 } else {
                     throw new IllegalArgumentException(
-                            "Invalid JSONP format: missing 'd=' prefix, got bytes: "
+                            "Invalid JSONP format: missing 'd=' prefix, got bytes: " +
                                      String.format("0x%02X 0x%02X", content.getByte(ri) & 0xFF, content.getByte(ri + 1) & 0xFF));
                 }
             }

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -77,7 +77,10 @@ public class PacketDecoder {
                 if (content.getByte(ri) == (byte) 'd' && content.getByte(ri + 1) == (byte) '=') {
                     content.readerIndex(ri + 2);
                 } else {
-                    throw new IllegalArgumentException("Invalid JSONP format: missing 'd=' prefix");
+                    byte b0 = content.getByte(ri);
+                    byte b1 = content.getByte(ri + 1);
+                    String received = String.format("0x%02X 0x%02X", b0, b1);
+                    throw new IllegalArgumentException("Invalid JSONP format: missing 'd=' prefix, got bytes: " + received);
                 }
             }
         }

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -77,7 +77,9 @@ public class PacketDecoder {
                 if (content.getByte(ri) == (byte) 'd' && content.getByte(ri + 1) == (byte) '=') {
                     content.readerIndex(ri + 2);
                 } else {
-                    throw new IllegalArgumentException("Invalid JSONP format: missing 'd=' prefix, got bytes: " + String.format("0x%02X 0x%02X", content.getByte(ri), content.getByte(ri + 1)));
+                    throw new IllegalArgumentException(
+                            "Invalid JSONP format: missing 'd=' prefix, got bytes: "
+                                     String.format("0x%02X 0x%02X", content.getByte(ri) & 0xFF, content.getByte(ri + 1) & 0xFF));
                 }
             }
         }


### PR DESCRIPTION
_This PR applies 1/1 suggestions from code quality [AI findings](https://github.com/socketio4j/netty-socketio/security/quality/ai-findings)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for malformed JSONP packet decoding: error messages now include the initial byte information in hex to make diagnostics clearer and help pinpoint unexpected input, reducing time to identify and resolve data-format issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->