### PR TITLE
support to configure decompression buffer

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/BasicConfiguration.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/BasicConfiguration.java
@@ -69,13 +69,6 @@ public abstract class BasicConfiguration {
     protected boolean websocketCompression = true;
     protected int decompressionBufferSize = 0;
 
-    public int getDecompressionBufferSize() {
-        return decompressionBufferSize;
-    }
-
-    public void setDecompressionBufferSize(int decompressionBufferSize) {
-        this.decompressionBufferSize = decompressionBufferSize;
-    }
 
     protected boolean randomSession = false;
 
@@ -460,6 +453,25 @@ public abstract class BasicConfiguration {
      */
     public void setWebsocketCompression(boolean websocketCompression) {
         this.websocketCompression = websocketCompression;
+    }
+
+    public int getDecompressionBufferSize() {
+        return decompressionBufferSize;
+    }
+
+    /**
+     * Set the maximum decompression buffer size for WebSocket compression.
+     * Used to limit memory consumption during WebSocket message decompression.
+     * <p>
+     * Default is <code>0</code> which means unlimited
+     *
+     * `@param` decompressionBufferSize - buffer size in bytes, or 0 for [unlimited/default]
+     */
+    public void setDecompressionBufferSize(int decompressionBufferSize) {
+        if (decompressionBufferSize < 0) {
+            throw new IllegalArgumentException("decompressionBufferSize must be non-negative");
+        }
+        this.decompressionBufferSize = decompressionBufferSize;
     }
 
     public boolean isWebsocketCompression() {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/BasicConfiguration.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/BasicConfiguration.java
@@ -67,6 +67,15 @@ public abstract class BasicConfiguration {
     protected boolean httpCompression = true;
 
     protected boolean websocketCompression = true;
+    protected int decompressionBufferSize = 0;
+
+    public int getDecompressionBufferSize() {
+        return decompressionBufferSize;
+    }
+
+    public void setDecompressionBufferSize(int decompressionBufferSize) {
+        this.decompressionBufferSize = decompressionBufferSize;
+    }
 
     protected boolean randomSession = false;
 
@@ -135,6 +144,7 @@ public abstract class BasicConfiguration {
 
         setHttpCompression(conf.isHttpCompression());
         setWebsocketCompression(conf.isWebsocketCompression());
+        setDecompressionBufferSize(conf.getDecompressionBufferSize());
         setRandomSession(conf.randomSession);
         setNeedClientAuth(conf.isNeedClientAuth());
         setMetrics(conf.getMetrics());

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/SocketIOChannelInitializer.java
@@ -195,7 +195,7 @@ public class SocketIOChannelInitializer extends ChannelInitializer<Channel> impl
         pipeline.addLast(AUTHORIZE_HANDLER, authorizeHandler);
         pipeline.addLast(XHR_POLLING_TRANSPORT, xhrPollingTransport);
         if (configuration.isWebsocketCompression()) {
-            pipeline.addLast(WEB_SOCKET_TRANSPORT_COMPRESSION, new WebSocketServerCompressionHandler());
+            pipeline.addLast(WEB_SOCKET_TRANSPORT_COMPRESSION, new WebSocketServerCompressionHandler(configuration.getDecompressionBufferSize()));
         }
         pipeline.addLast(WEB_SOCKET_TRANSPORT, webSocketTransport);
 


### PR DESCRIPTION
removed deprecated method which always support unlimited buffer, user can use decompressionBufferSize to set the limits

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #(issue number)

## Changes Made

- 
- 
- 

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [ ] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

Any additional information, screenshots, or context that reviewers should know.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable decompression buffer size for WebSocket compression to let users tune performance.

* **Bug Fixes**
  * Configuration now rejects negative buffer sizes, preventing invalid settings and runtime errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->