### PR TITLE
Support EIOv3 binary attachment decoding

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/handler/EncoderHandler.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/handler/EncoderHandler.java
@@ -36,6 +36,7 @@ import com.socketio4j.socketio.messages.HttpMessage;
 import com.socketio4j.socketio.messages.OutPacketMessage;
 import com.socketio4j.socketio.messages.XHROptionsMessage;
 import com.socketio4j.socketio.messages.XHRPostMessage;
+import com.socketio4j.socketio.protocol.EngineIOVersion;
 import com.socketio4j.socketio.protocol.Packet;
 import com.socketio4j.socketio.protocol.PacketEncoder;
 
@@ -337,7 +338,10 @@ public class EncoderHandler extends ChannelOutboundHandlerAdapter {
 
             for (ByteBuf buf : packet.getAttachments()) {
                 ByteBuf outBuf = encoder.allocateBuffer(ctx.alloc());
-                outBuf.writeByte(4);
+                if (EngineIOVersion.V3.equals(packet.getEngineIOVersion())
+                        || EngineIOVersion.V2.equals(packet.getEngineIOVersion())) {
+                    outBuf.writeByte(4);
+                }
                 outBuf.writeBytes(buf);
                 if (log.isTraceEnabled()) {
                     log.trace("Out attachment: {} sessionId: {}", ByteBufUtil.hexDump(outBuf), msg.getSessionId());

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/namespace/Namespace.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/namespace/Namespace.java
@@ -422,9 +422,16 @@ public class Namespace implements SocketIONamespace {
 
     public void dispatch(String room, Packet packet) {
         int size = forEachRoomClient(room, client -> {
+            packet.setEngineIOVersion(client.getEngineIOVersion());
+            if(log.isDebugEnabled()) {
+                log.debug("[DISPATCH] namespace={} room={} → sending '{}' to sessionId={} (EIO={})",
+                        name, room, packet.getName(), client.getSessionId(), packet.getEngineIOVersion());
+            }
             client.send(packet);
         });
-
+        if(log.isDebugEnabled()) {
+            log.debug("[DISPATCH] namespace={} room={} → found {} local client(s)", name, room, size);
+        }
         if (size > 0) {
             metrics.eventSent(name, size);
         }

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/namespace/Namespace.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/namespace/Namespace.java
@@ -423,13 +423,13 @@ public class Namespace implements SocketIONamespace {
     public void dispatch(String room, Packet packet) {
         int size = forEachRoomClient(room, client -> {
             packet.setEngineIOVersion(client.getEngineIOVersion());
-            if(log.isDebugEnabled()) {
+            if (log.isDebugEnabled()) {
                 log.debug("[DISPATCH] namespace={} room={} → sending '{}' to sessionId={} (EIO={})",
                         name, room, packet.getName(), client.getSessionId(), packet.getEngineIOVersion());
             }
             client.send(packet);
         });
-        if(log.isDebugEnabled()) {
+        if (log.isDebugEnabled()) {
             log.debug("[DISPATCH] namespace={} room={} → found {} local client(s)", name, room, size);
         }
         if (size > 0) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -466,8 +466,15 @@ public class PacketDecoder {
                 int headEndIndex = frame.bytesBefore((byte) -1);
                 if (headEndIndex != -1) {
                     int len = (int) readLong(frame, headEndIndex);
-                    payload = frame.slice(frame.readerIndex() + 1, len);
-                    frame.readerIndex(frame.readerIndex() + 1 + len);
+                    int payloadStart = frame.readerIndex() + 1; // skip 0xFF separator
+                    if (payloadStart + len > frame.writerIndex()) {
+                        throw new IOException("Malformed polling wrapper: length " + len
+                                + " exceeds remaining frame bytes " + (frame.writerIndex() - payloadStart));
+                    }
+                    payload = frame.slice(payloadStart, len);
+                    frame.readerIndex(payloadStart + len);
+                } else {
+                    throw new IOException("Malformed polling wrapper: missing 0xFF separator");
                 }
             }
 

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/protocol/PacketDecoder.java
@@ -364,11 +364,139 @@ public class PacketDecoder {
         }
     }
 
+    /**
+     * Decodes and appends an incoming binary attachment to the given packet.
+     * <p>
+     * Depending on the negotiated Engine.IO version and transport, the incoming buffer
+     * has different frame layouts:
+     * </p>
+     * 
+     * <h3>Engine.IO v3 (Socket.IO 2.x and older)</h3>
+     * <ul>
+     *   <li>
+     *     <b>WebSocket (Raw Binary Frame):</b>
+     *     <pre>
+     *     +---------------+---------------------------------+
+     *     | Byte 0        | Bytes 1..N                      |
+     *     +---------------+---------------------------------+
+     *     | Type (0x04)   | Raw binary payload              |
+     *     +---------------+---------------------------------+
+     *     </pre>
+     *     The leading byte value 4 (Engine.IO MESSAGE packet type) is stripped, and the 
+     *     remainder is base64-encoded and appended as an attachment.
+     *   </li>
+     *   <li>
+     *     <b>WebSocket/Polling (Base64 Text Frame):</b>
+     *     <pre>
+     *     +-----------------+-------------------------------+
+     *     | Bytes 0..1      | Bytes 2..N                    |
+     *     +-----------------+-------------------------------+
+     *     | Prefix ("b4")   | Base64 string payload         |
+     *     +-----------------+-------------------------------+
+     *     </pre>
+     *     The leading ASCII prefix "b4" is stripped, and the remaining base64 payload is 
+     *     appended directly without double-encoding.
+     *     <br>
+     *     Ref: <a href="https://github.com/socketio/engine.io-protocol/tree/v3#packet-string-encoding">Engine.IO v3 Packet String Encoding Spec</a>
+     *     <blockquote>
+     *     "Sometimes, it is not possible to send binary data over the transport [...]. In that case, 
+     *     the packet is encoded as a string, and prepended with a 'b' character. For example: a packet 
+     *     of type message containing the buffer &lt;01 02 03&gt; is encoded as 'b4AQID'"
+     *     </blockquote>
+     *   </li>
+     *   <li>
+     *     <b>Polling (Raw Binary Wrapper):</b>
+     *     <pre>
+     *     +--------+---------------+--------+---------------+--------------------+
+     *     | Byte 0 | Bytes 1..K    | Byte K | Byte K+1      | Bytes K+2..N       |
+     *     +--------+---------------+--------+---------------+--------------------+
+     *     | 0x01   | Length (ASCII) | 0xFF   | Type (0x04)   | Raw binary payload |
+     *     +--------+---------------+--------+---------------+--------------------+
+     *     </pre>
+     *     The binary envelope is stripped to retrieve the inner packet, which is then 
+     *     processed normally (stripping the type prefix as described above).
+     *     <br>
+     *     Ref: <a href="https://github.com/socketio/engine.io-protocol/tree/v3#payload">Engine.IO v3 Payload Spec</a>
+     *     <blockquote>
+     *     "If the payload contains at least one binary packet, the payload is encoded as a binary buffer:
+     *      - a binary indicator: 1 (representing a binary packet) or 0 (representing a string packet)
+     *      - the length of the packet (as a series of characters)
+     *      - a separator: 255
+     *      - the packet itself"
+     *     </blockquote>
+     *   </li>
+     * </ul>
+     * 
+     * <h3>Engine.IO v4 (Socket.IO 3.x and newer)</h3>
+     * <ul>
+     *   <li>
+     *     <b>WebSocket/Polling (Raw Binary Frame):</b>
+     *     <pre>
+     *     +-------------------------------------------------+
+     *     | Bytes 0..N                                      |
+     *     +-------------------------------------------------+
+     *     | Raw binary payload                              |
+     *     +-------------------------------------------------+
+     *     </pre>
+     *     Engine.IO v4 does not prepend any packet types or metadata to binary attachments. 
+     *     The entire buffer is base64-encoded as-is and stored.
+     *     <br>
+     *     Ref: <a href="https://socket.io/docs/v4/engine-io-protocol/">Engine.IO v4 Protocol Spec</a>
+     *     <blockquote>
+     *     "Binary packets are sent as-is without any modifications."
+     *     </blockquote>
+     *   </li>
+     * </ul>
+     *
+     * @param head         the client connection head
+     * @param frame        the incoming byte buffer frame
+     * @param binaryPacket the packet being assembled
+     * @return the packet if fully assembled (all attachments loaded), or an empty MESSAGE packet
+     * @throws IOException if a decoding error occurs
+     */
     private Packet addAttachment(ClientHead head, ByteBuf frame, Packet binaryPacket) throws IOException {
-        ByteBuf attachBuf = Base64.encode(frame);
-        binaryPacket.addAttachment(Unpooled.copiedBuffer(attachBuf));
-        attachBuf.release();
-        frame.skipBytes(frame.readableBytes());
+        EngineIOVersion version = head.getEngineIOVersion();
+        boolean isV3OrV2 = version == EngineIOVersion.V3 || version == EngineIOVersion.V2;
+
+        ByteBuf payload = frame;
+        if (isV3OrV2 && frame.readableBytes() > 0) {
+            // 1. Strip EIOv3 Polling binary payload wrapper if present: '1' + length + '-1' (255)
+            if (frame.getByte(frame.readerIndex()) == 1) {
+                frame.readByte(); // skip '1'
+                int headEndIndex = frame.bytesBefore((byte) -1);
+                if (headEndIndex != -1) {
+                    int len = (int) readLong(frame, headEndIndex);
+                    payload = frame.slice(frame.readerIndex() + 1, len);
+                    frame.readerIndex(frame.readerIndex() + 1 + len);
+                }
+            }
+
+            // 2. Strip EIOv3 packet type prefix: 'b4' or '4' on the payload
+            int ri = payload.readerIndex();
+            if (payload.readableBytes() >= 2 && payload.getByte(ri) == 'b' && payload.getByte(ri + 1) == '4') {
+                payload.readerIndex(ri + 2); // skip 'b4'
+                // Since it started with 'b4', it's already base64 encoded
+                binaryPacket.addAttachment(Unpooled.copiedBuffer(payload));
+            } else {
+                if (payload.readableBytes() >= 1 && payload.getByte(ri) == 4) {
+                    payload.readerIndex(ri + 1); // skip '4'
+                }
+                ByteBuf attachBuf = Base64.encode(payload);
+                binaryPacket.addAttachment(Unpooled.copiedBuffer(attachBuf));
+                attachBuf.release();
+            }
+
+            // Ensure parent frame is advanced if we bypassed the polling wrapper path
+            if (frame.readableBytes() > 0) {
+                frame.skipBytes(frame.readableBytes());
+            }
+        } else {
+            // EIOv4 default logic: base64-encode the raw binary frame as-is
+            ByteBuf attachBuf = Base64.encode(frame);
+            binaryPacket.addAttachment(Unpooled.copiedBuffer(attachBuf));
+            attachBuf.release();
+            frame.skipBytes(frame.readableBytes());
+        }
 
         if (binaryPacket.isAttachmentsLoaded()) {
             LinkedList<ByteBuf> slices = new LinkedList<>();
@@ -406,6 +534,11 @@ public class PacketDecoder {
     private void parseBody(ClientHead head, ByteBuf frame, Packet packet) throws IOException {
         // Early return for non-MESSAGE packets
         if (packet.getType() != PacketType.MESSAGE) {
+            return;
+        }
+
+        if (packet.hasAttachments() && !packet.isAttachmentsLoaded()) {
+            handleBinaryAttachments(head, frame, packet);
             return;
         }
 

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
@@ -20,14 +20,16 @@ package com.socketio4j.socketio.store.kafka.serialization;
  * @author https://github.com/sanjomo
  * @date 15/12/25 6:21 pm
  */
-
 import org.apache.kafka.common.serialization.Deserializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.socketio4j.socketio.store.event.EventMessage;
 
 public final class EventMessageDeserializer
@@ -37,15 +39,21 @@ public final class EventMessageDeserializer
     private static final ObjectMapper MAPPER;
 
     static {
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.socketio4j.socketio")
+                .allowIfBaseType("java.util")
+                .allowIfSubType("java.util.Arrays$")
+                .allowIfSubTypeIsArray()
+                .allowIfSubType("java.time")
+                .allowIfSubType("java.math")
+                .build();
+
         MAPPER = JsonMapper.builder()
+                .polymorphicTypeValidator(ptv)
                 .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
                 .build();
-        MAPPER.activateDefaultTyping(
-                MAPPER.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
-        );
+        MAPPER.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
     }
 
     @Override

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
@@ -34,11 +34,19 @@ public final class EventMessageDeserializer
         implements Deserializer<EventMessage> {
     private static final Logger log = LoggerFactory.getLogger(EventMessageDeserializer.class);
 
-    private static final ObjectMapper MAPPER =
-            JsonMapper.builder()
-                    .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-                    .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
-                    .build();
+    private static final ObjectMapper MAPPER;
+
+    static {
+        MAPPER = JsonMapper.builder()
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+                .build();
+        MAPPER.activateDefaultTyping(
+                MAPPER.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+        );
+    }
 
     @Override
     public EventMessage deserialize(String topic, byte[] data) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
@@ -36,11 +36,19 @@ public final class EventMessageSerializer
         implements Serializer<EventMessage> {
     private static final Logger log = LoggerFactory.getLogger(EventMessageSerializer.class);
 
-    private static final ObjectMapper MAPPER =
-            JsonMapper.builder()
-                    .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                    .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
-                    .build();
+    private static final ObjectMapper MAPPER;
+
+    static {
+        MAPPER = JsonMapper.builder()
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+                .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+                .build();
+        MAPPER.activateDefaultTyping(
+                MAPPER.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+        );
+    }
 
     @Override
     public byte[] serialize(String topic, EventMessage data) {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
@@ -20,6 +20,7 @@ package com.socketio4j.socketio.store.kafka.serialization;
  * @author https://github.com/sanjomo
  * @date 15/12/25 6:21 pm
  */
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
@@ -20,16 +20,16 @@ package com.socketio4j.socketio.store.kafka.serialization;
  * @author https://github.com/sanjomo
  * @date 15/12/25 6:21 pm
  */
-
-import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.socketio4j.socketio.store.event.EventMessage;
 
 public final class EventMessageSerializer
@@ -39,15 +39,21 @@ public final class EventMessageSerializer
     private static final ObjectMapper MAPPER;
 
     static {
-        MAPPER = JsonMapper.builder()
-                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-                .disable(MapperFeature.DEFAULT_VIEW_INCLUSION)
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.socketio4j.socketio")
+                .allowIfBaseType("java.util")
+                .allowIfSubType("java.util.Arrays$")
+                .allowIfSubTypeIsArray()
+                .allowIfSubType("java.time")
+                .allowIfSubType("java.math")
                 .build();
-        MAPPER.activateDefaultTyping(
-                MAPPER.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
-        );
+
+        MAPPER = JsonMapper.builder()
+                .polymorphicTypeValidator(ptv)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+                .build();
+        MAPPER.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
     }
 
     @Override

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
@@ -21,7 +21,12 @@ package com.socketio4j.socketio.store.nats_pubsub;
  * @date 22/12/25 4:04 pm
  */
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.socketio4j.socketio.store.event.EventMessage;
 
 public final class EventMessageCodec {
@@ -29,17 +34,21 @@ public final class EventMessageCodec {
     private static final ObjectMapper MAPPER;
 
     static {
-        MAPPER = new ObjectMapper();
-        MAPPER.configure(
-                com.fasterxml.jackson.databind.DeserializationFeature
-                        .FAIL_ON_UNKNOWN_PROPERTIES,
-                false
-        );
-        MAPPER.activateDefaultTyping(
-                MAPPER.getPolymorphicTypeValidator(),
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
-        );
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.socketio4j.socketio")
+                .allowIfBaseType("java.util")
+                .allowIfSubType("java.util.Arrays$")
+                .allowIfSubTypeIsArray()
+                .allowIfSubType("java.time")
+                .allowIfSubType("java.math")
+                .build();
+
+        MAPPER = JsonMapper.builder()
+                .polymorphicTypeValidator(ptv)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(DeserializationFeature.FAIL_ON_INVALID_SUBTYPE)
+                .build();
+        MAPPER.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
     }
 
     private EventMessageCodec() {

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
@@ -35,6 +35,11 @@ public final class EventMessageCodec {
                         .FAIL_ON_UNKNOWN_PROPERTIES,
                 false
         );
+        MAPPER.activateDefaultTyping(
+                MAPPER.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                com.fasterxml.jackson.annotation.JsonTypeInfo.As.PROPERTY
+        );
     }
 
     private EventMessageCodec() {

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedCommonTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedCommonTest.java
@@ -16,8 +16,8 @@
  */
 package com.socketio4j.socketio.integration;
 
-
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -28,9 +28,18 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Supplier;
 
 import org.json.JSONArray;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 
@@ -43,483 +52,937 @@ import io.socket.client.Ack;
 import io.socket.client.IO;
 import io.socket.client.Socket;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Two-node cluster scenarios over a shared {@link com.socketio4j.socketio.store.StoreFactory}.
- * Single-node room semantics are also covered by {@link RoomBroadcastTest} and namespace tests;
- * this suite focuses on cross-node JOIN/DISPATCH timing.
+ * Two-node cluster integration scenarios over a shared {@link com.socketio4j.socketio.store.StoreFactory}.
+ *
+ * <p><strong>Design philosophy</strong>:
+ * <ul>
+ *   <li>Every test uses deterministic latches; no raw {@code Thread.sleep} calls.</li>
+ *   <li>Sockets are always disconnected in a {@code finally} block so that a test failure
+ *       cannot leave dangling connections that corrupt subsequent tests.</li>
+ *   <li>Negative-path assertions (messages that must <em>not</em> arrive) use a bounded
+ *       await of {@value #NEGATIVE_ASSERT_MS} ms — long enough for the distributed store
+ *       to propagate a spurious message, short enough not to slow the suite.</li>
+ *   <li>Room-membership sync is verified by {@link #awaitRoomSync} before any broadcast,
+ *       eliminating the race between "join" and "send".</li>
+ *   <li>Lazy {@link Supplier}-based failure messages avoid expensive string concatenation
+ *       on the happy path.</li>
+ * </ul>
  *
  * @author https://github.com/sanjomo
- * @date 11/12/25 3:53 pm
+ * @date 11/12/25 3:53 pm
  */
 public abstract class DistributedCommonTest {
+
+    // ─── Timing constants ────────────────────────────────────────────────────
+
+    /** Maximum seconds any single latch-based operation should take. */
+    private static final long OP_TIMEOUT_SECS = 30L;
+
+    /**
+     * Millisecond budget for a <em>negative</em> assertion ("this must NOT arrive").
+     * Must be long enough for the distributed store to propagate a spurious delivery,
+     * but short enough not to slow the suite materially.
+     */
+    private static final long NEGATIVE_ASSERT_MS = 1000L;
+
+    // ─── Abstract node handles ────────────────────────────────────────────────
 
     protected SocketIOServer node1;
     protected SocketIOServer node2;
 
     protected int port1;
     protected int port2;
-    
-    // ===================================================================
-    //   0. TWO NODES ROOM BROADCAST
-    // ===================================================================
+
+    // =========================================================================
+    //  Test 0 – Two nodes, same room: every client receives every broadcast
+    // =========================================================================
+
+    /**
+     * Verifies that when two clients are in the <em>same</em> room on different nodes,
+     * a broadcast from each node is received by both clients.
+     *
+     * <pre>
+     *   a (node1) ─── room ─── b (node2)
+     *   node1.sendEvent("m1") → a ✔, b ✔
+     *   node2.sendEvent("m2") → a ✔, b ✔
+     * </pre>
+     */
     @Test
+    @DisplayName("0 – two-node room broadcast: all clients receive all messages")
     public void testTwoNodesRoomBroadcast() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
-        final int clients = 2;
+        final String room    = uniqueRoom();
+        final int clients    = 2;
         final int broadcasts = 2;
-        final int expectedTotalMsgs = clients * broadcasts;
 
         CountDownLatch connectLatch = new CountDownLatch(clients);
-        CountDownLatch joinLatch = new CountDownLatch(clients);
-        CountDownLatch msgLatch = new CountDownLatch(expectedTotalMsgs);
+        CountDownLatch joinLatch    = new CountDownLatch(clients);
+        CountDownLatch msgLatch     = new CountDownLatch(clients * broadcasts);
 
         List<String> aMsgs = new CopyOnWriteArrayList<>();
         List<String> bMsgs = new CopyOnWriteArrayList<>();
 
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-
-        // --- SETUP LISTENERS ---
-        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-
-        a.on("join-ok", data -> joinLatch.countDown());
-        b.on("join-ok", data -> joinLatch.countDown());
-
-        a.on("room-event", data -> {
-            if (data.length > 0) {
-                aMsgs.add((String) data[0]);
-                msgLatch.countDown();
-            }
-        });
-
-        b.on("room-event", data -> {
-            if (data.length > 0) {
-                bMsgs.add((String) data[0]);
-                msgLatch.countDown();
-            }
-        });
-
-        // --- EXECUTION ---
-        a.connect();
-        b.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-
-        a.emit("join-room", room);
-        b.emit("join-room", room);
-        //Thread.sleep(3000);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-
-        awaitRoomSync(room, clients);
-
-        node1.getRoomOperations(room).sendEvent("room-event", "m1");
-        node2.getRoomOperations(room).sendEvent("room-event", "m2");
-
-        assertTrue(msgLatch.await(5, TimeUnit.SECONDS), "Did not receive all messages");
-
-        // --- ASSERTIONS ---
+        Socket a = newSocket(port1);
+        Socket b = newSocket(port2);
         try {
-            assertEquals(2, aMsgs.size());
-            assertEquals(2, bMsgs.size());
-            assertTrue(aMsgs.containsAll(Arrays.asList("m1", "m2")), "A missing m1/m2");
-            assertTrue(bMsgs.containsAll(Arrays.asList("m1", "m2")), "B missing m1/m2");
+            a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            a.on("join-ok", args -> joinLatch.countDown());
+            b.on("join-ok", args -> joinLatch.countDown());
+            a.on("room-event", args -> {
+                if (args.length > 0) { aMsgs.add((String) args[0]); msgLatch.countDown(); }
+            });
+            b.on("room-event", args -> {
+                if (args.length > 0) { bMsgs.add((String) args[0]); msgLatch.countDown(); }
+            });
+
+            a.connect();
+            b.connect();
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+
+            a.emit("join-room", room);
+            b.emit("join-room", room);
+            awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Clients failed to join room");
+            awaitRoomSync(room, clients);
+
+            node1.getRoomOperations(room).sendEvent("room-event", "m1");
+            node2.getRoomOperations(room).sendEvent("room-event", "m2");
+
+            awaitOrFail(msgLatch, OP_TIMEOUT_SECS,
+                    () -> "Expected " + (clients * broadcasts) + " messages; "
+                        + "a=" + aMsgs + ", b=" + bMsgs);
+
+            assertEquals(broadcasts, aMsgs.size(),
+                    () -> "Client a expected " + broadcasts + " msgs, got: " + aMsgs);
+            assertEquals(broadcasts, bMsgs.size(),
+                    () -> "Client b expected " + broadcasts + " msgs, got: " + bMsgs);
+
+            Set<String> expected = new HashSet<>(Arrays.asList("m1", "m2"));
+            assertEquals(expected, new HashSet<>(aMsgs), "Client a missing messages");
+            assertEquals(expected, new HashSet<>(bMsgs), "Client b missing messages");
+
         } finally {
-            a.disconnect();
-            b.disconnect();
+            disconnectAll(a, b);
         }
     }
 
+    // =========================================================================
+    //  Test 1 – Room members receive; non-members do NOT
+    // =========================================================================
 
-    // ===================================================================
-    //   1. MULTIPLE CLIENTS — ROOM MEMBERS RECEIVE, NON-MEMBERS DO NOT
-    // ===================================================================
+    /**
+     * With 4 clients (a1, a2 on node1 and b1, b2 on node2), only a1 and b1 join the room.
+     * A broadcast to that room must reach a1 and b1 <em>exclusively</em>.
+     */
     @Test
+    @DisplayName("1 – room members receive message; non-members are excluded")
     public void testRoomBroadcastMultipleClients() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
+        final String room = uniqueRoom();
 
-        final int allClients = 4;
-        CountDownLatch connectLatch = new CountDownLatch(allClients);
-        CountDownLatch joinLatch = new CountDownLatch(2); // a1, b1 join
+        CountDownLatch connectLatch   = new CountDownLatch(4);
+        CountDownLatch joinLatch      = new CountDownLatch(2);
+        CountDownLatch memberLatch    = new CountDownLatch(2);
+        CountDownLatch nonMemberLatch = new CountDownLatch(1);
 
-        CountDownLatch latchRoom = new CountDownLatch(2); // a1, b1 receive
+        AtomicReferenceArray<String> msg = new AtomicReferenceArray<>(4);
 
-        AtomicReferenceArray<String> msg =
-                new AtomicReferenceArray<>(allClients);
-        // Store 4 results
+        Socket a1 = newSocket(port1);
+        Socket a2 = newSocket(port1);
+        Socket b1 = newSocket(port2);
+        Socket b2 = newSocket(port2);
+        try {
+            a1.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            a2.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b1.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b2.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
 
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
+            a1.on("join-ok", args -> joinLatch.countDown());
+            b1.on("join-ok", args -> joinLatch.countDown());
 
-        Socket a1 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b1 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
+            a1.on("room-event", args -> {
+                if (args.length > 0) { msg.set(0, (String) args[0]); memberLatch.countDown(); }
+            });
+            b1.on("room-event", args -> {
+                if (args.length > 0) { msg.set(2, (String) args[0]); memberLatch.countDown(); }
+            });
+            a2.on("room-event", args -> {
+                if (args.length > 0) { msg.set(1, (String) args[0]); nonMemberLatch.countDown(); }
+            });
+            b2.on("room-event", args -> {
+                if (args.length > 0) { msg.set(3, (String) args[0]); nonMemberLatch.countDown(); }
+            });
 
+            connectAll(connectLatch, a1, a2, b1, b2);
 
-        Socket a2 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b2 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
+            a1.emit("join-room", room);
+            b1.emit("join-room", room);
+            awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Room members failed to join");
+            awaitRoomSync(room, 2);
 
-        // Connection listeners
-        a1.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        a2.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b1.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b2.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            node1.getRoomOperations(room).sendEvent("room-event", "hello");
 
-        // Join listeners (only a1 and b1 care)
-        a1.on("join-ok", data -> joinLatch.countDown());
-        b1.on("join-ok", data -> joinLatch.countDown());
+            awaitOrFail(memberLatch, OP_TIMEOUT_SECS, "Room members did not receive message");
+            assertEquals("hello", msg.get(0), "a1 must receive message");
+            assertEquals("hello", msg.get(2), "b1 must receive message");
 
+            boolean spurious = nonMemberLatch.await(NEGATIVE_ASSERT_MS, TimeUnit.MILLISECONDS);
+            assertFalse(spurious, "Non-room clients must NOT receive the room broadcast");
+            assertNull(msg.get(1), "a2 must not have received a message");
+            assertNull(msg.get(3), "b2 must not have received a message");
 
-        a1.connect();
-        a2.connect();
-        b1.connect();
-        b2.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "All clients failed to connect");
-
-        a1.emit("join-room", room);
-        b1.emit("join-room", room);
-        awaitRoomSync(room, 2);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-        CountDownLatch unexpectedLatch = new CountDownLatch(2);
-
-        // Give adapter time to sync room state
-        //Thread.sleep(500);
-        a1.on("room-event", data -> {
-            if (data.length > 0) {
-                latchRoom.countDown();
-                msg.set(0, (String) data[0]);
-            }
-        });
-        b1.on("room-event", data -> {
-            if (data.length > 0) {
-                latchRoom.countDown();
-                msg.set(2, (String) data[0]);
-            }
-        });
-        a2.on("room-event", data -> {
-            if (data.length > 0) {
-                unexpectedLatch.countDown(); // Should not happen
-                msg.set(1, (String) data[0]);
-            }
-        });
-        b2.on("room-event", data -> {
-            if (data.length > 0) {
-                unexpectedLatch.countDown(); // Should not happen
-                msg.set(3, (String) data[0]);
-            }
-        });
-        node1.getRoomOperations(room).sendEvent("room-event", "hello");
-
-        //Thread.sleep(2000);
-
-
-
-        assertTrue(latchRoom.await(3, TimeUnit.SECONDS), "Room members did not receive message");
-        assertFalse(unexpectedLatch.await(256, TimeUnit.MILLISECONDS), "Non-room clients should not receive messages");
-        assertEquals("hello", msg.get(0)); // a1 received
-        assertEquals("hello", msg.get(2)); // b1 received
-        assertNull(msg.get(1)); // a2 did not receive
-        assertNull(msg.get(3)); // b2 did not receive
-
-        a1.disconnect();
-        a2.disconnect();
-        b1.disconnect();
-        b2.disconnect();
+        } finally {
+            disconnectAll(a1, a2, b1, b2);
+        }
     }
 
-    // ===================================================================
-    //   2. BROADCAST FROM BOTH NODES (Cleaned up unsafe array)
-    // ===================================================================
+    // =========================================================================
+    //  Test 2 – All room members on both nodes receive broadcasts from both nodes
+    // =========================================================================
+
+    /**
+     * All 4 clients (2 per node) join the same room. A broadcast from each node must
+     * be received by every client exactly once, resulting in exactly 2 distinct messages
+     * per client and exactly {@code clientCount × broadcastCount} total deliveries.
+     */
     @Test
+    @DisplayName("2 – all room members on both nodes receive broadcasts from both nodes")
     public void testRoomBroadcastFromBothNodes() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
-        final int clientCount = 4;
-        final int expectedBroadcasts = 2; // m1 and m2
+        final String room        = uniqueRoom();
+        final int clientCount    = 4;
+        final int broadcastCount = 2;
+        final int expectedTotal  = clientCount * broadcastCount;
+
         CountDownLatch connectLatch = new CountDownLatch(clientCount);
-        CountDownLatch joinLatch = new CountDownLatch(clientCount);
-        CountDownLatch msgLatch = new CountDownLatch(clientCount * expectedBroadcasts); // 8 total
-
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket a1 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b1 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-
-
-        Socket a2 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b2 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
+        CountDownLatch joinLatch    = new CountDownLatch(clientCount);
+        CountDownLatch msgLatch     = new CountDownLatch(expectedTotal);
 
         Set<String> a1Data = ConcurrentHashMap.newKeySet();
         Set<String> a2Data = ConcurrentHashMap.newKeySet();
         Set<String> b1Data = ConcurrentHashMap.newKeySet();
         Set<String> b2Data = ConcurrentHashMap.newKeySet();
 
+        Socket a1 = newSocket(port1);
+        Socket a2 = newSocket(port1);
+        Socket b1 = newSocket(port2);
+        Socket b2 = newSocket(port2);
+        try {
+            registerCounters(connectLatch, joinLatch, a1, a2, b1, b2);
+            a1.on("room-event", args -> { a1Data.add((String) args[0]); msgLatch.countDown(); });
+            a2.on("room-event", args -> { a2Data.add((String) args[0]); msgLatch.countDown(); });
+            b1.on("room-event", args -> { b1Data.add((String) args[0]); msgLatch.countDown(); });
+            b2.on("room-event", args -> { b2Data.add((String) args[0]); msgLatch.countDown(); });
 
-        a1.on("room-event", args -> {
-            msgLatch.countDown();
-            a1Data.add((String) args[0]);
-        });
-        a2.on("room-event", args -> {
-            msgLatch.countDown();
-            a2Data.add((String) args[0]);
-        });
-        b1.on("room-event", args -> {
-            msgLatch.countDown();
-            b1Data.add((String) args[0]);
-        });
-        b2.on("room-event", args -> {
-            msgLatch.countDown();
-            b2Data.add((String) args[0]);
-        });
+            connectAll(connectLatch, a1, a2, b1, b2);
+            joinRoom(joinLatch, room, a1, a2, b1, b2);
+            awaitRoomSync(room, clientCount);
 
-        // Add connection/join listeners
-        List<Socket> allClients = Arrays.asList(a1, a2, b1, b2);
-        allClients.forEach(c -> c.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown()));
-        allClients.forEach(c -> c.on("join-ok", args -> joinLatch.countDown()));
+            node1.getRoomOperations(room).sendEvent("room-event", "m1");
+            node2.getRoomOperations(room).sendEvent("room-event", "m2");
 
+            awaitOrFail(msgLatch, OP_TIMEOUT_SECS,
+                    () -> "Expected " + expectedTotal + " total deliveries; "
+                        + "a1=" + a1Data + " a2=" + a2Data
+                        + " b1=" + b1Data + " b2=" + b2Data);
 
-        a1.connect();
-        a2.connect();
-        b1.connect();
-        b2.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
+            Set<String> expected = new HashSet<>(Arrays.asList("m1", "m2"));
+            assertEquals(expected, a1Data, "a1 message set mismatch");
+            assertEquals(expected, a2Data, "a2 message set mismatch");
+            assertEquals(expected, b1Data, "b1 message set mismatch");
+            assertEquals(expected, b2Data, "b2 message set mismatch");
+            assertEquals(expectedTotal,
+                    a1Data.size() + a2Data.size() + b1Data.size() + b2Data.size(),
+                    "Aggregate delivery count mismatch — possible duplicate delivery");
 
-        a1.emit("join-room", room);
-        a2.emit("join-room", room);
-        b1.emit("join-room", room);
-        b2.emit("join-room", room);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-        awaitRoomSync(room, 4);
-
-        node1.getRoomOperations(room).sendEvent("room-event", "m1");
-        node2.getRoomOperations(room).sendEvent("room-event", "m2");
-
-        //Thread.sleep(1000);
-
-        assertTrue(msgLatch.await(5, TimeUnit.SECONDS), "Did not receive all 8 events");
-        assertEquals(8, a1Data.size() + a2Data.size() + b1Data.size() + b2Data.size(), "Each client must receive 2 messages");
-        Set<String> expected = new HashSet<>(Arrays.asList("m1", "m2"));
-        assertEquals(expected, a1Data);
-        assertEquals(expected, b1Data);
-        assertEquals(expected, a2Data);
-        assertEquals(expected, b2Data);
-        a1.disconnect();
-        a2.disconnect();
-        b1.disconnect();
-        b2.disconnect();
+        } finally {
+            disconnectAll(a1, a2, b1, b2);
+        }
     }
 
-    // ===================================================================
-    //   3. LEAVE ROOM — MUST NOT RECEIVE (Fixed non-deterministic sleep)
-    // ===================================================================
-    @Test
-    public void testRoomLeave() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        CountDownLatch joinLatch = new CountDownLatch(2);
-
-        AtomicReferenceArray<String> msg =
-                new AtomicReferenceArray<>(2); // msg[0]=a, msg[1]=b
-
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-
-        // Connection/Join Listeners
-        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        a.on("join-ok", data -> joinLatch.countDown());
-        b.on("join-ok", data -> joinLatch.countDown());
-
-        a.connect();
-        b.connect();
-
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-
-        a.emit("join-room", room);
-        b.emit("join-room", room);
-        awaitRoomSync(room, 2);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-
-        // ---- FIRST BROADCAST ----
-        CountDownLatch latchFirst = new CountDownLatch(2);
-        a.off("room-event");
-        b.off("room-event");
-        a.on("room-event", args -> {
-            msg.set(0, (String) args[0]);
-            latchFirst.countDown();
-        });
-        b.on("room-event", args -> {
-            msg.set(1, (String) args[0]);
-            latchFirst.countDown();
-        });
-
-        node1.getRoomOperations(room).sendEvent("room-event", "first");
-        assertTrue(latchFirst.await(2, TimeUnit.SECONDS), "First broadcast failed");
-        assertEquals("first", msg.get(0));
-        assertEquals("first", msg.get(1));
-
-        // ---- b LEAVES ----
-        CountDownLatch leaveLatch = new CountDownLatch(1);
-        b.on("leave-ok", data -> leaveLatch.countDown()); // Listen for leave ack
-        b.emit("leave-room", room);
-        assertTrue(leaveLatch.await(2, TimeUnit.SECONDS), "Client B failed to leave room");
-        awaitRoomSync(room, 1);
-
-        // Reset message storage for second broadcast
-        msg.set(0, null);
-        msg.set(1, null);
-
-        // ---- SECOND BROADCAST ----
-        CountDownLatch latchSecond = new CountDownLatch(1); // Only A should receive
-        a.off("room-event"); // Clear old latch on A
-        a.on("room-event", args -> {
-            msg.set(0, (String) args[0]);
-            latchSecond.countDown();
-        });
-
-        // B's listener is still active, but should not receive the message
-        // B's listener will NOT countdown the latchSecond (latchSecond = 1)
-
-        node1.getRoomOperations(room).sendEvent("room-event", "second");
-
-        assertTrue(latchSecond.await(2, TimeUnit.SECONDS), "Client A did not receive second message");
-        assertEquals("second", msg.get(0)); // A MUST receive
-
-        assertNull(msg.get(1), "Client B received message despite leaving the room!");
-
-        b.off("room-event");
-        a.disconnect();
-        b.disconnect();
-    }
-
-
-    // ===================================================================
-    //   4. JOIN AFTER BROADCAST — NO BACKFILL (Fixed non-deterministic sleep)
-    // ===================================================================
-    @Test
-    public void testJoinAfterBroadcastNoBackfill() throws Exception {
-
-        String room = "room-" + UUID.randomUUID();
-
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        CountDownLatch joinLatchA = new CountDownLatch(1);
-        CountDownLatch joinLatchB = new CountDownLatch(1);
-
-        CountDownLatch earlyLatch = new CountDownLatch(1);
-        CountDownLatch lateLatch  = new CountDownLatch(2);
-        AtomicReferenceArray<String> joinMsg =
-                new AtomicReferenceArray<>(2);
-        AtomicReferenceArray<String> roomMsg =
-                new AtomicReferenceArray<>(2);
-
-
-        IO.Options opts = new IO.Options();
-        opts.forceNew = true;
-
-        Socket a = IO.socket("http://localhost:" + port1, opts);
-        Socket b = IO.socket("http://localhost:" + port2, opts);
-
-        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-
-        a.on("join-ok", args -> {
-            joinMsg.set(0, (String) args[0]);
-            joinLatchA.countDown();
-        });
-
-        b.on("join-ok", args -> {
-            joinMsg.set(1, (String) args[0]);
-            joinLatchB.countDown();
-        });
-
-        // ---- ROOM EVENT LISTENERS (NO off(), NO reuse)
-        a.on("room-event", args -> {
-            String v = (String) args[0];
-            if ("early".equals(v)) {
-                roomMsg.set(0, v);
-                earlyLatch.countDown();
-            } else if ("late".equals(v)) {
-                roomMsg.set(0, v);
-                lateLatch.countDown();
-            }
-        });
-
-        b.on("room-event", args -> {
-            String v = (String) args[0];
-            if ("late".equals(v)) {
-                roomMsg.set(1, v);
-                lateLatch.countDown();
-            }
-        });
-
-        // ---- CONNECT
-        a.connect();
-        b.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS));
-
-        // ---- A joins first
-        a.emit("join-room", room);
-        assertTrue(joinLatchA.await(2, TimeUnit.SECONDS));
-        assertEquals("OK", joinMsg.get(0));
-
-        // ---- EARLY broadcast
-        node1.getRoomOperations(room).sendEvent("room-event", "early");
-        assertTrue(earlyLatch.await(2, TimeUnit.SECONDS));
-        assertEquals("early", roomMsg.get(0));
-        assertNull(roomMsg.get(1));
-
-        // ---- B joins late
-        b.emit("join-room", room);
-        assertTrue(joinLatchB.await(2, TimeUnit.SECONDS));
-
-        // ---- WAIT FOR DISTRIBUTED ROOM SYNC
-        awaitRoomSync(room, 2);
-
-        // ---- LATE broadcast
-        node2.getRoomOperations(room).sendEvent("room-event", "late");
-        assertTrue(lateLatch.await(2, TimeUnit.SECONDS));
-
-        assertEquals("late", roomMsg.get(0));
-        assertEquals("late", roomMsg.get(1));
-
-        a.disconnect();
-        b.disconnect();
-    }
+    // =========================================================================
+    //  Test 3 – Leave room: departed client must NOT receive subsequent broadcast
+    // =========================================================================
 
     /**
-     * Waits until both nodes have replicated the room membership (same UUID set size on each).
-     * {@link com.socketio4j.socketio.BroadcastOperations#getClients()} only returns locally connected
-     * clients and is not sufficient as a cross-node barrier.
+     * Verifies that a client that emits {@code leave-room} no longer receives room events.
+     *
+     * <ol>
+     *   <li><strong>First broadcast</strong>: both clients receive "first".</li>
+     *   <li>Client b leaves (server acknowledges with "leave-ok").</li>
+     *   <li><strong>Second broadcast</strong>: only a receives "second"; b must not.</li>
+     * </ol>
+     */
+    @Test
+    @DisplayName("3 – leave-room: departed client does not receive subsequent broadcasts")
+    public void testRoomLeave() throws Exception {
+        final String room = uniqueRoom();
+
+        CountDownLatch connectLatch = new CountDownLatch(2);
+        CountDownLatch joinLatch    = new CountDownLatch(2);
+        AtomicReferenceArray<String> msg = new AtomicReferenceArray<>(2);
+
+        Socket a = newSocket(port1);
+        Socket b = newSocket(port2);
+        try {
+            a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            a.on("join-ok", args -> joinLatch.countDown());
+            b.on("join-ok", args -> joinLatch.countDown());
+
+            a.connect();
+            b.connect();
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+
+            a.emit("join-room", room);
+            b.emit("join-room", room);
+            awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Clients failed to join room");
+            awaitRoomSync(room, 2);
+
+            // Phase 1: both receive
+            CountDownLatch firstLatch = new CountDownLatch(2);
+            a.on("room-event", args -> { msg.set(0, (String) args[0]); firstLatch.countDown(); });
+            b.on("room-event", args -> { msg.set(1, (String) args[0]); firstLatch.countDown(); });
+
+            node1.getRoomOperations(room).sendEvent("room-event", "first");
+            awaitOrFail(firstLatch, OP_TIMEOUT_SECS, "First broadcast failed");
+            assertEquals("first", msg.get(0), "a must receive first broadcast");
+            assertEquals("first", msg.get(1), "b must receive first broadcast");
+
+            // b leaves
+            CountDownLatch leaveLatch = new CountDownLatch(1);
+            b.on("leave-ok", args -> leaveLatch.countDown());
+            b.emit("leave-room", room);
+            awaitOrFail(leaveLatch, OP_TIMEOUT_SECS, "Client b failed to leave room");
+            awaitRoomSync(room, 1);
+
+            msg.set(0, null);
+            msg.set(1, null);
+            a.off("room-event");
+            b.off("room-event");
+
+            // Phase 2: only a receives
+            CountDownLatch secondLatch    = new CountDownLatch(1);
+            CountDownLatch bSpuriousLatch = new CountDownLatch(1);
+
+            a.on("room-event", args -> { msg.set(0, (String) args[0]); secondLatch.countDown(); });
+            b.on("room-event", args -> { msg.set(1, (String) args[0]); bSpuriousLatch.countDown(); });
+
+            node1.getRoomOperations(room).sendEvent("room-event", "second");
+            awaitOrFail(secondLatch, OP_TIMEOUT_SECS, "Client a did not receive second broadcast");
+            assertEquals("second", msg.get(0), "a must receive second broadcast");
+
+            boolean bGotMessage = bSpuriousLatch.await(NEGATIVE_ASSERT_MS, TimeUnit.MILLISECONDS);
+            assertFalse(bGotMessage, "Client b received a message after leaving the room");
+            assertNull(msg.get(1), "b's message slot must remain null after leaving");
+
+        } finally {
+            disconnectAll(a, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 4 – Late joiner: no backfill of pre-join events
+    // =========================================================================
+
+    /**
+     * Verifies that the distributed store does <em>not</em> replay historical events
+     * to a client that joined after those events were emitted.
+     *
+     * <pre>
+     *   a joins → node1 sends "early" → a ✔, b not yet in room
+     *   b joins → node2 sends "late"  → a ✔, b ✔
+     *   b must NOT have received "early"
+     * </pre>
+     */
+    @Test
+    @DisplayName("4 – late joiner receives only post-join broadcasts; no backfill")
+    public void testJoinAfterBroadcastNoBackfill() throws Exception {
+        final String room = uniqueRoom();
+
+        CountDownLatch connectLatch = new CountDownLatch(3); // +1 for sentinel
+        CountDownLatch joinLatchA   = new CountDownLatch(1);
+        CountDownLatch joinLatchSentinel = new CountDownLatch(1); // To sync node2
+        CountDownLatch joinLatchB   = new CountDownLatch(1);
+        CountDownLatch earlyLatch   = new CountDownLatch(2); // Wait for a AND sentinel
+        CountDownLatch lateLatch    = new CountDownLatch(2);
+
+        AtomicReferenceArray<String> roomMsg  = new AtomicReferenceArray<>(2);
+        AtomicReference<String>      bEarlyMsg = new AtomicReference<>(null);
+
+        Socket a = IO.socket(url(port1), baseOptions());
+        Socket sentinel = IO.socket(url(port2), baseOptions()); // Listens on node2
+        Socket b = IO.socket(url(port2), baseOptions());
+
+        try {
+            a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            sentinel.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+
+            a.on("join-ok", args -> joinLatchA.countDown());
+            sentinel.on("join-ok", args -> joinLatchSentinel.countDown());
+            b.on("join-ok", args -> joinLatchB.countDown());
+
+            a.on("room-event", args -> {
+                if ("early".equals(args[0])) earlyLatch.countDown();
+                else if ("late".equals(args[0])) { roomMsg.set(0, (String) args[0]); lateLatch.countDown(); }
+            });
+
+            sentinel.on("room-event", args -> {
+                // This guarantees Node2's Kafka consumer has processed the message
+                if ("early".equals(args[0])) earlyLatch.countDown();
+            });
+
+            b.on("room-event", args -> {
+                String v = (String) args[0];
+                if ("early".equals(v)) { bEarlyMsg.set(v); }
+                else if ("late".equals(v)) { roomMsg.set(1, v); lateLatch.countDown(); }
+            });
+
+            a.connect();
+            sentinel.connect();
+            b.connect();
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+
+            // 1. Setup initial clients
+            a.emit("join-room", room);
+            sentinel.emit("join-room", room);
+            awaitOrFail(joinLatchA, OP_TIMEOUT_SECS, "a failed to join room");
+            awaitOrFail(joinLatchSentinel, OP_TIMEOUT_SECS, "sentinel failed to join room");
+
+            // 2. Publish Early Message
+            node1.getRoomOperations(room).sendEvent("room-event", "early");
+
+            // 3. CRITICAL SYNC: Wait for Node 1 (a) AND Node 2 (sentinel) to process it
+            awaitOrFail(earlyLatch, OP_TIMEOUT_SECS, "Failed to route early message through Kafka");
+
+            // 4. NOW it is safe for b to join Node 2
+            b.emit("join-room", room);
+            awaitOrFail(joinLatchB, OP_TIMEOUT_SECS, "b failed to join room");
+            awaitRoomSync(room, 3); // a, sentinel, b
+
+            // 5. Publish Late Message
+            node2.getRoomOperations(room).sendEvent("room-event", "late");
+            awaitOrFail(lateLatch, OP_TIMEOUT_SECS, "Late broadcast not received");
+
+            // 6. Assertions
+            assertEquals("late", roomMsg.get(0), "a must receive 'late'");
+            assertEquals("late", roomMsg.get(1), "b must receive 'late'");
+            assertNull(bEarlyMsg.get(), "b joined late but received 'early' — backfill leak detected!");
+
+        } finally {
+            disconnectAll(a, sentinel, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 5 – Except-sender: the emitting client does not receive the event
+    // =========================================================================
+
+    /**
+     * Broadcasts to all room members <em>except</em> the designated sender.
+     * Asserts that b receives the event and a (the sender) does not.
+     */
+    @Test
+    @DisplayName("5 – except-sender: emitter is excluded; other room members receive")
+    public void testSendExceptSender() throws Exception {
+        final String room = uniqueRoom();
+
+        CountDownLatch connectLatch   = new CountDownLatch(2);
+        CountDownLatch joinLatch      = new CountDownLatch(2);
+        CountDownLatch bReceiveLatch  = new CountDownLatch(1);
+        CountDownLatch aSpuriousLatch = new CountDownLatch(1);
+
+        AtomicReferenceArray<String> msg = new AtomicReferenceArray<>(2);
+
+        Socket a = IO.socket(url(port1), baseOptions());
+        Socket b = IO.socket(url(port2), baseOptions());
+        try {
+            a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            a.on("join-ok", args -> joinLatch.countDown());
+            b.on("join-ok", args -> joinLatch.countDown());
+
+            a.on("room-event", args -> { msg.set(0, (String) args[0]); aSpuriousLatch.countDown(); });
+            b.on("room-event", args -> { msg.set(1, (String) args[0]); bReceiveLatch.countDown(); });
+
+            a.connect();
+            b.connect();
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+
+            a.emit("join-room", room);
+            b.emit("join-room", room);
+            awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Clients failed to join room");
+            awaitRoomSync(room, 2);
+
+            sendExcept(room, "room-event", "hello", a.id());
+
+            awaitOrFail(bReceiveLatch, OP_TIMEOUT_SECS, "Client b did not receive the event");
+            assertEquals("hello", msg.get(1), "b must receive the event payload");
+
+            boolean aGotMessage = aSpuriousLatch.await(NEGATIVE_ASSERT_MS, TimeUnit.MILLISECONDS);
+            assertFalse(aGotMessage, "Sender (a) must not receive its own broadcast");
+            assertNull(msg.get(0), "a's message slot must remain null");
+
+        } finally {
+            disconnectAll(a, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 6 – Multiple rooms: messages must not leak across room boundaries
+    // =========================================================================
+
+    /**
+     * Two clients each join <em>different</em> rooms. A broadcast to roomA must reach only
+     * the client in roomA; a broadcast to roomB must reach only the client in roomB.
+     * This is verified in both directions.
+     */
+    @Test
+    @DisplayName("6 – multiple rooms: no cross-room message leakage")
+    public void testMultipleRoomsNoLeakage() throws Exception {
+        final String roomA = uniqueRoom("roomA");
+        final String roomB = uniqueRoom("roomB");
+
+        CountDownLatch connectLatch = new CountDownLatch(2);
+        CountDownLatch joinLatch    = new CountDownLatch(2);
+
+        AtomicReferenceArray<String> msgA = new AtomicReferenceArray<>(1);
+        AtomicReferenceArray<String> msgB = new AtomicReferenceArray<>(1);
+
+        Socket a = newSocket(port1);
+        Socket b = newSocket(port2);
+        try {
+            a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            a.on("join-ok", args -> joinLatch.countDown());
+            b.on("join-ok", args -> joinLatch.countDown());
+
+            a.connect();
+            b.connect();
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+
+            a.emit("join-room", roomA);
+            b.emit("join-room", roomB);
+            awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Clients failed to join rooms");
+            awaitRoomSync(roomA, 1);
+            awaitRoomSync(roomB, 1);
+
+            // Phase 1: broadcast to roomA — only a receives
+            CountDownLatch aLatch         = new CountDownLatch(1);
+            CountDownLatch bSpuriousLatch = new CountDownLatch(1);
+            a.on("room-event", args -> { msgA.set(0, (String) args[0]); aLatch.countDown(); });
+            b.on("room-event", args -> { msgB.set(0, (String) args[0]); bSpuriousLatch.countDown(); });
+
+            node1.getRoomOperations(roomA).sendEvent("room-event", "a");
+            awaitOrFail(aLatch, OP_TIMEOUT_SECS, "Client a did not receive roomA message");
+            assertEquals("a", msgA.get(0), "a must receive roomA broadcast");
+            assertFalse(bSpuriousLatch.await(NEGATIVE_ASSERT_MS, TimeUnit.MILLISECONDS),
+                    "b must NOT receive roomA broadcast");
+            assertNull(msgB.get(0), "b's slot must remain null after roomA broadcast");
+
+            // Phase 2: broadcast to roomB — only b receives
+            msgA.set(0, null);
+            msgB.set(0, null);
+            a.off("room-event");
+            b.off("room-event");
+
+            CountDownLatch bLatch         = new CountDownLatch(1);
+            CountDownLatch aSpuriousLatch = new CountDownLatch(1);
+            a.on("room-event", args -> { msgA.set(0, (String) args[0]); aSpuriousLatch.countDown(); });
+            b.on("room-event", args -> { msgB.set(0, (String) args[0]); bLatch.countDown(); });
+
+            node2.getRoomOperations(roomB).sendEvent("room-event", "b");
+            awaitOrFail(bLatch, OP_TIMEOUT_SECS, "Client b did not receive roomB message");
+            assertEquals("b", msgB.get(0), "b must receive roomB broadcast");
+            assertFalse(aSpuriousLatch.await(NEGATIVE_ASSERT_MS, TimeUnit.MILLISECONDS),
+                    "a must NOT receive roomB broadcast");
+            assertNull(msgA.get(0), "a's slot must remain null after roomB broadcast");
+
+        } finally {
+            disconnectAll(a, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 7 – Global broadcast: all connected clients receive, regardless of room
+    // =========================================================================
+
+    /**
+     * Server-level broadcast (no room filter) from each node must reach every connected
+     * client on both nodes. Each client must receive exactly the 2 messages, with no
+     * duplicates — verified by an aggregate count assertion.
+     */
+    @Test
+    @DisplayName("7 – global broadcast: all clients on all nodes receive all events")
+    public void testPureBroadcastFromBothNodes() throws Exception {
+        final String room        = uniqueRoom();
+        final int clientCount    = 4;
+        final int broadcastCount = 2;
+        final int expectedTotal  = clientCount * broadcastCount;
+
+        CountDownLatch connectLatch = new CountDownLatch(clientCount);
+        CountDownLatch joinLatch    = new CountDownLatch(clientCount);
+        CountDownLatch msgLatch     = new CountDownLatch(expectedTotal);
+
+        Set<String> a1Data = ConcurrentHashMap.newKeySet();
+        Set<String> a2Data = ConcurrentHashMap.newKeySet();
+        Set<String> b1Data = ConcurrentHashMap.newKeySet();
+        Set<String> b2Data = ConcurrentHashMap.newKeySet();
+
+        Socket a1 = IO.socket(url(port1), baseOptions());
+        Socket a2 = IO.socket(url(port1), baseOptions());
+        Socket b1 = IO.socket(url(port2), baseOptions());
+        Socket b2 = IO.socket(url(port2), baseOptions());
+        try {
+            registerCounters(connectLatch, joinLatch, a1, a2, b1, b2);
+            a1.on("room-event", args -> { a1Data.add((String) args[0]); msgLatch.countDown(); });
+            a2.on("room-event", args -> { a2Data.add((String) args[0]); msgLatch.countDown(); });
+            b1.on("room-event", args -> { b1Data.add((String) args[0]); msgLatch.countDown(); });
+            b2.on("room-event", args -> { b2Data.add((String) args[0]); msgLatch.countDown(); });
+
+            connectAll(connectLatch, a1, a2, b1, b2);
+            joinRoom(joinLatch, room, a1, a2, b1, b2);
+            awaitRoomSync(room, clientCount);
+
+            node1.getBroadcastOperations().sendEvent("room-event", "m1");
+            node2.getBroadcastOperations().sendEvent("room-event", "m2");
+
+            awaitOrFail(msgLatch, OP_TIMEOUT_SECS,
+                    () -> "Expected " + expectedTotal + " deliveries; "
+                        + "a1=" + a1Data + " a2=" + a2Data
+                        + " b1=" + b1Data + " b2=" + b2Data);
+
+            Set<String> expected = new HashSet<>(Arrays.asList("m1", "m2"));
+            assertEquals(expected, new HashSet<>(a1Data), "a1 mismatch");
+            assertEquals(expected, new HashSet<>(a2Data), "a2 mismatch");
+            assertEquals(expected, new HashSet<>(b1Data), "b1 mismatch");
+            assertEquals(expected, new HashSet<>(b2Data), "b2 mismatch");
+            assertEquals(expectedTotal,
+                    a1Data.size() + a2Data.size() + b1Data.size() + b2Data.size(),
+                    "Aggregate count mismatch – possible duplicate delivery");
+
+        } finally {
+            disconnectAll(a1, a2, b1, b2);
+        }
+    }
+
+    // =========================================================================
+    //  Test 8 – Sequential global broadcasts: node1 then node2
+    // =========================================================================
+
+    /**
+     * Broadcasts are issued sequentially (node1 first, then node2 only after all clients
+     * have acknowledged the first). This prevents the two message sets from interleaving
+     * and makes per-client assertions unambiguous.
+     */
+    @Test
+    @DisplayName("8 – sequential global broadcasts: node1 then node2, all clients receive")
+    public void testPureBroadcastFromNodes() throws Exception {
+        final int clientCount = 4;
+        // A dedicated sync room is used purely to give awaitRoomSync a stable
+        // predicate: once both nodes see all 4 clients in this room, we know
+        // that Hazelcast has fully propagated every CONNECT event and it is
+        // safe to call getBroadcastOperations().
+        final String syncRoom = uniqueRoom("sync");
+
+        CountDownLatch connectLatch = new CountDownLatch(clientCount);
+        CountDownLatch joinLatch    = new CountDownLatch(clientCount);
+
+        Socket c1 = IO.socket(url(port1), baseOptions());
+        Socket c2 = IO.socket(url(port1), baseOptions());
+        Socket c3 = IO.socket(url(port2), baseOptions());
+        Socket c4 = IO.socket(url(port2), baseOptions());
+        try {
+            registerCounters(connectLatch, joinLatch, c1, c2, c3, c4);
+            connectAll(connectLatch, c1, c2, c3, c4);
+
+            // Join a sync room so awaitRoomSync can deterministically confirm
+            // both nodes have processed the CONNECT events for all 4 clients.
+            joinRoom(joinLatch, syncRoom, c1, c2, c3, c4);
+            awaitRoomSync(syncRoom, clientCount);
+
+            // Phase 1: broadcast from node1
+            CountDownLatch latch1 = new CountDownLatch(clientCount);
+            AtomicReferenceArray<String> msg1 = new AtomicReferenceArray<>(clientCount);
+            c1.off("room-event").on("room-event", args -> { msg1.set(0, (String) args[0]); latch1.countDown(); });
+            c2.off("room-event").on("room-event", args -> { msg1.set(1, (String) args[0]); latch1.countDown(); });
+            c3.off("room-event").on("room-event", args -> { msg1.set(2, (String) args[0]); latch1.countDown(); });
+            c4.off("room-event").on("room-event", args -> { msg1.set(3, (String) args[0]); latch1.countDown(); });
+
+            node1.getBroadcastOperations().sendEvent("room-event", "m1");
+            awaitOrFail(latch1, OP_TIMEOUT_SECS, "Phase-1 broadcast (from node1) failed");
+            for (int i = 0; i < clientCount; i++) {
+                assertEquals("m1", msg1.get(i), "Client c" + (i + 1) + " did not receive m1");
+            }
+
+            // Phase 2: broadcast from node2
+            CountDownLatch latch2 = new CountDownLatch(clientCount);
+            AtomicReferenceArray<String> msg2 = new AtomicReferenceArray<>(clientCount);
+            c1.off("room-event").on("room-event", args -> { msg2.set(0, (String) args[0]); latch2.countDown(); });
+            c2.off("room-event").on("room-event", args -> { msg2.set(1, (String) args[0]); latch2.countDown(); });
+            c3.off("room-event").on("room-event", args -> { msg2.set(2, (String) args[0]); latch2.countDown(); });
+            c4.off("room-event").on("room-event", args -> { msg2.set(3, (String) args[0]); latch2.countDown(); });
+
+            node2.getBroadcastOperations().sendEvent("room-event", "m2");
+            awaitOrFail(latch2, OP_TIMEOUT_SECS, "Phase-2 broadcast (from node2) failed");
+            for (int i = 0; i < clientCount; i++) {
+                assertEquals("m2", msg2.get(i), "Client c" + (i + 1) + " did not receive m2");
+            }
+
+        } finally {
+            disconnectAll(c1, c2, c3, c4);
+        }
+    }
+
+    // =========================================================================
+    //  Test 9 – Connect with room embedded in query string (different rooms)
+    // =========================================================================
+
+    /**
+     * Clients pass their room via {@code ?join=<room>} in the URL so the server auto-joins
+     * them on connect. Each client's room list must contain exactly the default namespace
+     * room and the requested room.
+     */
+    @Test
+    @DisplayName("9 – connect with query-join: each client joins its designated room")
+    public void testConnectAndJoinDifferentRoomTest() throws Exception {
+        final String room1 = uniqueRoom();
+        final String room2 = uniqueRoom();
+
+        Socket a = IO.socket(url(port1) + "?join=" + room1, baseOptions());
+        Socket b = IO.socket(url(port2) + "?join=" + room2, baseOptions());
+
+        CountDownLatch connectLatch = new CountDownLatch(2);
+        CountDownLatch ackLatch     = new CountDownLatch(2);
+
+        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+
+        a.connect();
+        b.connect();
+        try {
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+            awaitRoomSync(room1, 1);
+            awaitRoomSync(room2, 1);
+
+            CompletableFuture<Void> f1 = new CompletableFuture<>();
+            CompletableFuture<Void> f2 = new CompletableFuture<>();
+
+            a.emit("get-my-rooms", "ping", (Ack) ackArgs -> {
+                try {
+                    JSONAssert.assertEquals(new JSONArray(Arrays.asList("", room1)),
+                            (JSONArray) ackArgs[0], false);
+                    f1.complete(null);
+                    ackLatch.countDown();
+                } catch (Exception e) { f1.completeExceptionally(e); }
+            });
+
+            b.emit("get-my-rooms", "ping", (Ack) ackArgs -> {
+                try {
+                    JSONAssert.assertEquals(new JSONArray(Arrays.asList("", room2)),
+                            (JSONArray) ackArgs[0], false);
+                    f2.complete(null);
+                    ackLatch.countDown();
+                } catch (Exception e) { f2.completeExceptionally(e); }
+            });
+
+            assertDoesNotThrow(
+                    () -> CompletableFuture.allOf(f1, f2).get(OP_TIMEOUT_SECS, TimeUnit.SECONDS),
+                    "get-my-rooms ack assertion failed");
+            awaitOrFail(ackLatch, OP_TIMEOUT_SECS, "get-my-rooms acks not received");
+
+        } finally {
+            disconnectAll(a, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 10 – Both clients join the same room via query string
+    // =========================================================================
+
+    /**
+     * Both clients use the same room in the URL query parameter. Each client's room list
+     * must contain the default namespace room and the shared room.
+     */
+    @Test
+    @DisplayName("10 – connect with query-join: both clients join the same room")
+    public void testConnectAndJoinSameRoomTest() throws Exception {
+        final String room = uniqueRoom();
+
+        Socket a = IO.socket(url(port1) + "?join=" + room, baseOptions());
+        Socket b = IO.socket(url(port2) + "?join=" + room, baseOptions());
+
+        CountDownLatch connectLatch = new CountDownLatch(2);
+        CountDownLatch ackLatch     = new CountDownLatch(2);
+
+        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+
+        a.connect();
+        b.connect();
+        try {
+            awaitOrFail(connectLatch, OP_TIMEOUT_SECS, "Clients failed to connect");
+            awaitRoomSync(room, 2);
+
+            CompletableFuture<Void> f1 = new CompletableFuture<>();
+            CompletableFuture<Void> f2 = new CompletableFuture<>();
+
+            a.emit("get-my-rooms", "ping", (Ack) ackArgs -> {
+                try {
+                    JSONAssert.assertEquals(new JSONArray(Arrays.asList("", room)),
+                            (JSONArray) ackArgs[0], false);
+                    f1.complete(null);
+                    ackLatch.countDown();
+                } catch (Exception e) { f1.completeExceptionally(e); }
+            });
+
+            b.emit("get-my-rooms", "ping", (Ack) ackArgs -> {
+                try {
+                    JSONAssert.assertEquals(new JSONArray(Arrays.asList("", room)),
+                            (JSONArray) ackArgs[0], false);
+                    f2.complete(null);
+                    ackLatch.countDown();
+                } catch (Exception e) { f2.completeExceptionally(e); }
+            });
+
+            assertDoesNotThrow(
+                    () -> CompletableFuture.allOf(f1, f2).get(OP_TIMEOUT_SECS, TimeUnit.SECONDS),
+                    "get-my-rooms ack assertion failed");
+            awaitOrFail(ackLatch, OP_TIMEOUT_SECS, "get-my-rooms acks not received");
+
+        } finally {
+            disconnectAll(a, b);
+        }
+    }
+
+    // =========================================================================
+    //  Test 11 – EIO v3 binary packet forwarded across nodes
+    // =========================================================================
+
+    /**
+     * An EIO v3 raw WebSocket client on node1 sends a binary event. Node1 broadcasts
+     * the binary payload to all room members; a standard Socket.IO client on node2
+     * must receive the correct binary bytes.
+     *
+     * <p>EIO v3 binary framing:
+     * <pre>
+     *   text frame:   "451-[\"clientBinary\",{\"_placeholder\":true,\"num\":0}]"
+     *   binary frame: [0x04, 0x64, 0x6E, 0x78]  (prefix=4, payload=[100,110,120])
+     * </pre>
+     */
+    @Test
+    @DisplayName("11 – EIO v3 binary forwarding: binary payload delivered cross-node")
+    public void testTwoNodesEIOv3BinaryForwarding() throws Exception {
+        final String room = "room-binary-" + UUID.randomUUID();
+
+        AtomicReference<byte[]> receivedOnNode2 = new AtomicReference<>();
+        CountDownLatch msgLatch       = new CountDownLatch(1);
+        CountDownLatch joinReadyLatch = new CountDownLatch(1);
+
+        node1.addEventListener("clientBinary", byte[].class, (client, data, ack) ->
+                node1.getRoomOperations(room).sendEvent("serverBinary", data));
+
+        Socket clientB = IO.socket(url(port2), baseOptions());
+        try {
+            clientB.on(Socket.EVENT_CONNECT, args -> clientB.emit("join-room", room));
+            clientB.on("join-ok", args -> joinReadyLatch.countDown());
+            clientB.on("serverBinary", data -> {
+                if (data.length > 0) { receivedOnNode2.set((byte[]) data[0]); msgLatch.countDown(); }
+            });
+
+            clientB.connect();
+            awaitOrFail(joinReadyLatch, OP_TIMEOUT_SECS, "Client B failed to join room on node2");
+            awaitRoomSync(room, 1);
+
+            OkHttpClient okClient = new OkHttpClient.Builder()
+                    .connectTimeout(5, TimeUnit.SECONDS)
+                    .readTimeout(5, TimeUnit.SECONDS)
+                    .build();
+
+            Request request = new Request.Builder()
+                    .url("ws://localhost:" + port1 + "/socket.io/?EIO=3&transport=websocket")
+                    .build();
+
+            AtomicReference<WebSocket> eio3SocketRef = new AtomicReference<>();
+            CountDownLatch handshakeLatch = new CountDownLatch(1);
+
+            WebSocket eio3Socket = okClient.newWebSocket(request, new WebSocketListener() {
+                @Override
+                public void onOpen(WebSocket webSocket, okhttp3.Response response) {
+                    eio3SocketRef.set(webSocket);
+                }
+
+                @Override
+                public void onMessage(WebSocket webSocket, String text) {
+                    if (text.startsWith("0")) handshakeLatch.countDown();
+                }
+
+                @Override
+                public void onFailure(WebSocket webSocket, Throwable t, okhttp3.Response response) {
+                    handshakeLatch.countDown();
+                }
+            });
+
+            try {
+                awaitOrFail(handshakeLatch, OP_TIMEOUT_SECS, "EIO v3 client handshake failed");
+                eio3Socket.send("40");
+                eio3Socket.send("451-[\"clientBinary\",{\"_placeholder\":true,\"num\":0}]");
+                eio3Socket.send(ByteString.of(new byte[]{4, 100, 110, 120}));
+
+                awaitOrFail(msgLatch, OP_TIMEOUT_SECS,
+                        "Binary payload was not received by client B on node2");
+
+                byte[] expected = {100, 110, 120};
+                assertNotNull(receivedOnNode2.get(), "Received binary payload must not be null");
+                assertArrayEquals(expected, receivedOnNode2.get(),
+                        "Binary payload bytes mismatch");
+
+            } finally {
+                eio3Socket.close(1000, "test-complete");
+            }
+
+        } finally {
+            disconnectAll(clientB);
+        }
+    }
+
+    // =========================================================================
+    //  Shared infrastructure
+    // =========================================================================
+
+    /**
+     * Polls both nodes until both report exactly {@code expected} clients in {@code room},
+     * stable for 3 consecutive 8 ms ticks. Eliminates the race between a "join-ok" ack
+     * and the membership being replicated to the peer node.
      */
     private void awaitRoomSync(String room, int expected) throws InterruptedException {
-        long deadline = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
+        long deadline   = System.currentTimeMillis() + Duration.ofMinutes(2).toMillis();
         int stableTicks = 0;
+
         while (System.currentTimeMillis() < deadline) {
             int n1 = roomClientsInCluster(node1, room);
             int n2 = roomClientsInCluster(node2, room);
             if (n1 == expected && n2 == expected) {
-                stableTicks++;
-                if (stableTicks >= 3) {
-                    return;
-                }
+                if (++stableTicks >= 3) return;
             } else {
                 stableTicks = 0;
             }
             Thread.sleep(8);
         }
-        fail("Room sync not completed for " + room + " (expected " + expected + " on each node, got "
-                + roomClientsInCluster(node1, room) + " / " + roomClientsInCluster(node2, room) + ")");
+
+        fail(String.format(
+                "Room '%s' sync timed out: expected %d on each node, got node1=%d / node2=%d",
+                room, expected,
+                roomClientsInCluster(node1, room),
+                roomClientsInCluster(node2, room)));
     }
 
     private static int roomClientsInCluster(SocketIOServer server, String room) {
@@ -529,468 +992,114 @@ public abstract class DistributedCommonTest {
     private static Namespace defaultNamespace(SocketIOServer server) {
         SocketIONamespace ns = server.getNamespace(Namespace.DEFAULT_NAME);
         if (!(ns instanceof Namespace)) {
-            throw new IllegalStateException("Default namespace must be " + Namespace.class.getName());
+            throw new IllegalStateException(
+                    "Expected " + Namespace.class.getName() + " but got " + ns.getClass().getName());
         }
         return (Namespace) ns;
     }
 
-
-
-    // ===================================================================
-    //   5. EXCEPT SENDER — SENDER MUST NOT RECEIVE (Fixed helper logic)
-    // ===================================================================
-    @Test
-    public void testSendExceptSender() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
-
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        CountDownLatch joinLatch = new CountDownLatch(2);
-
-        AtomicReferenceArray<String> msg =
-                new AtomicReferenceArray<>(2);
-        CountDownLatch latchReceive = new CountDownLatch(1); // Only B should receive
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-        // Connection/Join Listeners
-        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        a.on("join-ok", data -> joinLatch.countDown());
-        b.on("join-ok", data -> joinLatch.countDown());
-        a.on("room-event", args -> {
-            msg.set(0, (String) args[0]);
-            latchReceive.countDown();
-        });
-        b.on("room-event", args -> {
-            msg.set(1, (String) args[0]);
-            latchReceive.countDown();
-        });
-        a.connect();
-        b.connect();
-        //Thread.sleep(2000);
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-
-        a.emit("join-room", room);
-        b.emit("join-room", room);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-
-        awaitRoomSync(room, 2);
-
-        // Emit from a custom method that finds all clients *except* 'a' and sends to them.
-        sendExcept(room, "room-event", "hello", a.id());
-
-        assertTrue(latchReceive.await(2, TimeUnit.SECONDS), "Client B did not receive message");
-        assertEquals("hello", msg.get(1)); // b receives
-        assertNull(msg.get(0));            // a does NOT receive
-
-        a.disconnect();
-        b.disconnect();
-    }
-    // Helper method to send event except to a specific sender ID
-    private void sendExcept(String room, String event, String data, String senderId) {
-        // Must check both nodes to ensure the distributed room list is correctly queried
-        for (SocketIOServer s : Arrays.asList(node1, node2)) {
-            for (SocketIOClient c : s.getRoomOperations(room).getClients()) {
-                if (!c.getSessionId().toString().equals(senderId)) {
-                    // Send directly to the client's session
-                    c.sendEvent(event, data);
+    /**
+     * Sends {@code event} with {@code data} to every client in {@code room} on both nodes,
+     * skipping the client whose session ID equals {@code excludedId}.
+     */
+    private void sendExcept(String room, String event, String data, String excludedId) {
+        for (SocketIOServer server : Arrays.asList(node1, node2)) {
+            for (SocketIOClient client : server.getRoomOperations(room).getClients()) {
+                if (!client.getSessionId().toString().equals(excludedId)) {
+                    client.sendEvent(event, data);
                 }
             }
         }
     }
 
+    // ── Assertion helpers ─────────────────────────────────────────────────────
 
-    // ===================================================================
-    //   6. MULTIPLE ROOMS — NO CROSS TALK (Fixed non-deterministic sleep)
-    // ===================================================================
-    @Test
-    public void testMultipleRoomsNoLeakage() throws Exception {
-        final String roomA = "roomA-" + UUID.randomUUID();
-        final String roomB = "roomB-" + UUID.randomUUID();
-
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        CountDownLatch joinLatch = new CountDownLatch(2);
-
-        AtomicReferenceArray<String> msgA =
-                new AtomicReferenceArray<>(2);// client A's message storage
-        AtomicReferenceArray<String> msgB =
-                new AtomicReferenceArray<>(2); // client B's message storage
-
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket b = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-
-        // Connection/Join Listeners
-        a.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        b.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
-        a.on("join-ok", data -> joinLatch.countDown());
-        b.on("join-ok", data -> joinLatch.countDown());
-
-
-        a.connect();
-        b.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-
-        a.emit("join-room", roomA);
-        b.emit("join-room", roomB);
-        awaitRoomSync(roomA, 1);
-        awaitRoomSync(roomB, 1);
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS), "Clients failed to join room");
-
-        //Thread.sleep(500); // Give adapter time to sync room state
-
-        // ---- Broadcast to roomA ----
-        CountDownLatch latchA = new CountDownLatch(1);
-        a.off("room-event");
-        a.on("room-event", args -> {
-            msgA.set(0, (String) args[0]);
-            latchA.countDown();
-        });
-        b.off("room-event"); // ensure B is listening but for a different room
-
-        node1.getRoomOperations(roomA).sendEvent("room-event", "a");
-        assertTrue(latchA.await(2, TimeUnit.SECONDS), "Client A did not receive roomA message");
-
-        assertEquals("a", msgA.get(0));
-        assertNull(msgB.get(0), "Client B received message from roomA!");
-
-        // ---- Broadcast to roomB ----
-        msgA.set(0, null); // reset A
-        CountDownLatch latchB = new CountDownLatch(1);
-        b.off("room-event");
-        b.on("room-event", args -> {
-            msgB.set(0, (String) args[0]);
-            latchB.countDown();
-        });
-
-        node2.getRoomOperations(roomB).sendEvent("room-event", "b");
-        assertTrue(latchB.await(2, TimeUnit.SECONDS), "Client B did not receive roomB message");
-
-        assertEquals("b", msgB.get(0));
-        assertNull(msgA.get(0), "Client A received message from roomB!");
-
-        a.disconnect();
-        b.disconnect();
+    private static void awaitOrFail(CountDownLatch latch, long timeoutSecs, String message)
+            throws InterruptedException {
+        assertTrue(latch.await(timeoutSecs, TimeUnit.SECONDS), message);
     }
 
-    // ===================================================================
-    //   7. PURE BROADCAST — ALL CLIENTS ON ALL NODES MUST RECEIVE (Cleaned up unsafe array)
-    // ===================================================================
-    @Test
-    public void testPureBroadcastFromBothNodes() throws Exception {
-        final String room = "room-" + UUID.randomUUID();
+    private static void awaitOrFail(CountDownLatch latch, long timeoutSecs,
+                                     Supplier<String> messageSupplier)
+            throws InterruptedException {
+        assertTrue(latch.await(timeoutSecs, TimeUnit.SECONDS), messageSupplier);
+    }
 
-        final int clientCount = 4;
-        final int expectedBroadcasts = 2;
+    // ── Socket helpers ────────────────────────────────────────────────────────
 
-        CountDownLatch connectLatch = new CountDownLatch(clientCount);
-        CountDownLatch joinLatch = new CountDownLatch(clientCount);
-        CountDownLatch msgLatch =
-                new CountDownLatch(clientCount * expectedBroadcasts); // 8
-
+    private static IO.Options baseOptions() {
         IO.Options opts = new IO.Options();
         opts.forceNew = true;
-
-        Socket a1 = IO.socket("http://localhost:" + port1, opts);
-        Socket a2 = IO.socket("http://localhost:" + port1, opts);
-        Socket b1 = IO.socket("http://localhost:" + port2, opts);
-        Socket b2 = IO.socket("http://localhost:" + port2, opts);
-
-        Set<String> a1Data = ConcurrentHashMap.newKeySet();
-        Set<String> a2Data = ConcurrentHashMap.newKeySet();
-        Set<String> b1Data = ConcurrentHashMap.newKeySet();
-        Set<String> b2Data = ConcurrentHashMap.newKeySet();
-
-        a1.on("room-event", args -> {
-            a1Data.add((String) args[0]);
-            msgLatch.countDown();
-        });
-
-        a2.on("room-event", args -> {
-            a2Data.add((String) args[0]);
-            msgLatch.countDown();
-        });
-
-        b1.on("room-event", args -> {
-            b1Data.add((String) args[0]);
-            msgLatch.countDown();
-        });
-
-        b2.on("room-event", args -> {
-            b2Data.add((String) args[0]);
-            msgLatch.countDown();
-        });
-
-        List<Socket> allClients = Arrays.asList(a1, a2, b1, b2);
-
-        allClients.forEach(c ->
-                c.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown())
-        );
-
-        allClients.forEach(c ->
-                c.on("join-ok", args -> joinLatch.countDown())
-        );
-
-        a1.connect();
-        a2.connect();
-        b1.connect();
-        b2.connect();
-
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS),
-                "Clients failed to connect");
-
-        a1.emit("join-room", room);
-        a2.emit("join-room", room);
-        b1.emit("join-room", room);
-        b2.emit("join-room", room);
-
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS),
-                "Clients failed to join room");
-
-        awaitRoomSync(room, 4);
-
-        node1.getBroadcastOperations()
-                .sendEvent("room-event", "m1");
-
-        node2.getBroadcastOperations()
-                .sendEvent("room-event", "m2");
-
-        assertTrue(msgLatch.await(5, TimeUnit.SECONDS),
-                "Did not receive all 8 events");
-        assertEquals(8, a1Data.size() + a2Data.size() + b1Data.size() + b2Data.size(), "Each client must receive 2 messages");
-
-
-        Set<String> expected = new HashSet<>(Arrays.asList("m1", "m2"));
-
-        assertEquals(expected, new HashSet<>(a1Data), "a1 mismatch");
-        assertEquals(expected, new HashSet<>(a2Data), "a2 mismatch");
-        assertEquals(expected, new HashSet<>(b1Data), "b1 mismatch");
-        assertEquals(expected, new HashSet<>(b2Data), "b2 mismatch");
-
-        a1.disconnect();
-        a2.disconnect();
-        b1.disconnect();
-        b2.disconnect();
+        return opts;
     }
 
-
-    // ===================================================================
-    //   8) PURE BROADCAST — NODE1 THEN NODE2 — NO ROOMS (Cleaned up listener logic)
-    // ===================================================================
-    @Test
-    public void testPureBroadcastFromNodes() throws Exception {
-        final int clientCount = 4;
-        CountDownLatch connectLatch = new CountDownLatch(clientCount);
-
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-
-        Socket c1 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket c2 = io.socket.client.IO.socket("http://localhost:" + port1, opts);
-        Socket c3 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-        Socket c4 = io.socket.client.IO.socket("http://localhost:" + port2, opts);
-
-        List<Socket> allClients = Arrays.asList(c1, c2, c3, c4);
-        allClients.forEach(c -> c.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown()));
-
-        c1.connect();
-        c2.connect();
-        c3.connect();
-        c4.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-
-        // ---------------------------
-        // 1) BROADCAST FROM NODE 1
-        // ---------------------------
-        CountDownLatch latch1 = new CountDownLatch(clientCount);
-        AtomicReferenceArray<String> msg1 =
-                new AtomicReferenceArray<>(4);
-        c1.off("room-event").on("room-event", args -> {
-            msg1.set(0, (String) args[0]);
-            latch1.countDown();
-        });
-        c2.off("room-event").on("room-event", args -> {
-            msg1.set(1, (String) args[0]);
-            latch1.countDown();
-        });
-        c3.off("room-event").on("room-event", args -> {
-            msg1.set(2, (String) args[0]);
-            latch1.countDown();
-        });
-        c4.off("room-event").on("room-event", args -> {
-            msg1.set(3, (String) args[0]);
-            latch1.countDown();
-        });
-
-        node1.getBroadcastOperations().sendEvent("room-event", "m1");
-
-        assertTrue(latch1.await(5, TimeUnit.SECONDS), "Phase 1 broadcast failed");
-
-        assertEquals("m1", msg1.get(0));
-        assertEquals("m1", msg1.get(1));
-        assertEquals("m1", msg1.get(2));
-        assertEquals("m1", msg1.get(3));
-
-        // ---------------------------
-        // 2) BROADCAST FROM NODE 2
-        // ---------------------------
-        CountDownLatch latch2 = new CountDownLatch(clientCount);
-        AtomicReferenceArray<String> msg2 =
-                new AtomicReferenceArray<>(4);
-
-
-        c1.off("room-event").on("room-event", args -> {
-            msg2.set(0, (String) args[0]);
-            latch2.countDown(); });
-        c2.off("room-event").on("room-event", args -> {
-            msg2.set(1, (String) args[0]);
-            latch2.countDown();
-        });
-        c3.off("room-event").on("room-event", args -> {
-            msg2.set(2, (String) args[0]);
-            latch2.countDown();
-        });
-        c4.off("room-event").on("room-event", args -> {
-            msg2.set(3, (String) args[0]);
-            latch2.countDown();
-        });
-
-        node2.getBroadcastOperations().sendEvent("room-event", "m2");
-
-        assertTrue(latch2.await(5, TimeUnit.SECONDS), "Phase 2 broadcast failed");
-
-        assertEquals("m2", msg2.get(0));
-        assertEquals("m2", msg2.get(1));
-        assertEquals("m2", msg2.get(2));
-        assertEquals("m2", msg2.get(3));
-
-        c1.disconnect();
-        c2.disconnect();
-        c3.disconnect();
-        c4.disconnect();
+    private String url(int port) {
+        return "http://localhost:" + port;
     }
 
-    @Test
-    public void testConnectAndJoinDifferentRoomTest() throws Exception {
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-        String room = "room-" + UUID.randomUUID();
-        String room2 = "room-" + UUID.randomUUID();
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1 + "?join="+room, opts);
-        Socket b = io.socket.client.IO.socket("http://localhost:" + port2 + "?join="+room2, opts);
-
-
-        CountDownLatch joinLatch = new CountDownLatch(2);
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        a.on(Socket.EVENT_CONNECT, args -> {
-            connectLatch.countDown();
-        });
-        b.on(Socket.EVENT_CONNECT, args -> {
-            connectLatch.countDown();
-        });
-        a.connect();
-        b.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-        awaitRoomSync(room, 1);
-        awaitRoomSync(room2, 1);
-
-        CompletableFuture<Void> f1 = new CompletableFuture<>();
-        CompletableFuture<Void> f2 = new CompletableFuture<>();
-
-        a.emit("get-my-rooms", "anything", (Ack) ackArgs -> {
-            try {
-                JSONAssert.assertEquals(
-                        new JSONArray(Arrays.asList("", room)),
-                        (JSONArray) ackArgs[0],
-                        false
-                );
-                f1.complete(null);
-                joinLatch.countDown();
-            } catch (Exception t) {
-                f1.completeExceptionally(t);
-            }
-        });
-
-        b.emit("get-my-rooms", "anything", (Ack) ackArgs -> {
-            try {
-                JSONAssert.assertEquals(
-                        new JSONArray(Arrays.asList("", room2)),
-                        (JSONArray) ackArgs[0],
-                        false
-                );
-                f2.complete(null);
-                joinLatch.countDown();
-            } catch (Exception t) {
-                f2.completeExceptionally(t);
-            }
-        });
-
-        assertDoesNotThrow(() ->
-                CompletableFuture.allOf(f1, f2).get(5, TimeUnit.SECONDS)
-        );
-
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS));
+    /** Creates a new socket pointing at the given port using default options. */
+    private Socket newSocket(int port) {
+        try {
+            return IO.socket(url(port), baseOptions());
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create socket for port " + port, e);
+        }
     }
 
-    @Test
-    public void testConnectAndJoinSameRoomTest() throws Exception {
-        io.socket.client.IO.Options opts = new io.socket.client.IO.Options();
-        opts.forceNew = true;
-        String room = "room-" + UUID.randomUUID();
-        Socket a = io.socket.client.IO.socket("http://localhost:" + port1 + "?join=" + room, opts);
-        Socket b = IO.socket("http://localhost:" + port2 + "?join=" + room, opts);
+    /** Connects all sockets and awaits the connect latch. */
+    private void connectAll(CountDownLatch latch, Socket... sockets) throws InterruptedException {
+        for (Socket s : sockets) s.connect();
+        awaitOrFail(latch, OP_TIMEOUT_SECS, "Not all clients connected within timeout");
+    }
 
-        CountDownLatch joinLatch = new CountDownLatch(2);
-        CountDownLatch connectLatch = new CountDownLatch(2);
-        a.on(Socket.EVENT_CONNECT, args -> {
-            connectLatch.countDown();
-        });
-        b.on(Socket.EVENT_CONNECT, args -> {
-            connectLatch.countDown();
-        });
-        a.connect();
-        b.connect();
-        assertTrue(connectLatch.await(5, TimeUnit.SECONDS), "Clients failed to connect");
-        awaitRoomSync(room, 2);
-        CompletableFuture<Void> f1 = new CompletableFuture<>();
-        CompletableFuture<Void> f2 = new CompletableFuture<>();
+    /**
+     * Emits {@code join-room} from each socket and awaits the join latch.
+     * Each socket must already have a "join-ok" listener that counts down {@code joinLatch}.
+     */
+    private void joinRoom(CountDownLatch joinLatch, String room, Socket... sockets)
+            throws InterruptedException {
+        for (Socket s : sockets) s.emit("join-room", room);
+        awaitOrFail(joinLatch, OP_TIMEOUT_SECS, "Not all clients joined the room within timeout");
+    }
 
-        a.emit("get-my-rooms", "anything", (Ack) ackArgs -> {
-            try {
-                JSONAssert.assertEquals(
-                        new JSONArray(Arrays.asList("", room)),
-                        (JSONArray) ackArgs[0],
-                        false
-                );
-                f1.complete(null);
-                joinLatch.countDown();
-            } catch (Exception t) {
-                f1.completeExceptionally(t);
-            }
-        });
+    /**
+     * Registers connect and join-ok listeners on all provided sockets, decrementing the
+     * respective latches. Call before {@link #connectAll} and {@link #joinRoom}.
+     */
+    private static void registerCounters(CountDownLatch connectLatch, CountDownLatch joinLatch,
+                                          Socket... sockets) {
+        for (Socket s : sockets) {
+            s.on(Socket.EVENT_CONNECT, args -> connectLatch.countDown());
+            s.on("join-ok",           args -> joinLatch.countDown());
+        }
+    }
 
-        b.emit("get-my-rooms", "anything", (Ack) ackArgs -> {
-            try {
-                JSONAssert.assertEquals(
-                        new JSONArray(Arrays.asList("", room)),
-                        (JSONArray) ackArgs[0],
-                        false
-                );
-                f2.complete(null);
-                joinLatch.countDown();
-            } catch (Exception t) {
-                f2.completeExceptionally(t);
-            }
-        });
+    /**
+     * Disconnects every supplied socket. If any individual disconnect throws, the remaining
+     * sockets are still disconnected and all exceptions are re-thrown as suppressed causes.
+     */
+    private static void disconnectAll(Socket... sockets) {
+        List<Exception> errors = new ArrayList<>();
+        for (Socket s : sockets) {
+            try { s.disconnect(); } catch (Exception e) { errors.add(e); }
+        }
+        if (!errors.isEmpty()) {
+            RuntimeException ex = new RuntimeException(
+                    "One or more sockets failed to disconnect cleanly");
+            errors.forEach(ex::addSuppressed);
+            throw ex;
+        }
+    }
 
-        assertDoesNotThrow(() ->
-                CompletableFuture.allOf(f1, f2).get(5, TimeUnit.SECONDS)
-        );
+    // ── Room name helpers ─────────────────────────────────────────────────────
 
-        assertTrue(joinLatch.await(5, TimeUnit.SECONDS));
+    /** Unique room name to prevent state leakage between test runs. */
+    private static String uniqueRoom() {
+        return "room-" + UUID.randomUUID();
+    }
+
+    /** Unique room name with a human-readable prefix for easier log reading. */
+    private static String uniqueRoom(String prefix) {
+        return prefix + "-" + UUID.randomUUID();
     }
 }

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedInProcessHazelcastTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedInProcessHazelcastTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2025 The Socketio4j Project
+ * Parent project : Copyright (c) 2012-2025 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.socketio4j.socketio.integration;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.socketio4j.socketio.Configuration;
+import com.socketio4j.socketio.SocketIOServer;
+import com.socketio4j.socketio.store.hazelcast.HazelcastStoreFactory;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class DistributedInProcessHazelcastTest extends DistributedCommonTest {
+
+    private HazelcastInstance hz1;
+    private HazelcastInstance hz2;
+
+    @BeforeAll
+    public void setup() throws Exception {
+        // Configure Hazelcast to form a cluster in-process using loopback/local discovery
+        Config config = new Config();
+        config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+
+        hz1 = Hazelcast.newHazelcastInstance(config);
+        hz2 = Hazelcast.newHazelcastInstance(config);
+
+        // NODE 1
+        Configuration cfg1 = new Configuration();
+        DistributedClusterIntegrationSupport.applyReuseListenAddress(cfg1);
+        cfg1.setHostname("127.0.0.1");
+        cfg1.setPort(DistributedClusterIntegrationSupport.findAvailablePort());
+        cfg1.setStoreFactory(new HazelcastStoreFactory(hz1));
+        node1 = new SocketIOServer(cfg1);
+        DistributedClusterIntegrationSupport.attachDefaultRoomListeners(node1);
+        node1.start();
+        port1 = cfg1.getPort();
+
+        // NODE 2
+        Configuration cfg2 = new Configuration();
+        DistributedClusterIntegrationSupport.applyReuseListenAddress(cfg2);
+        cfg2.setHostname("127.0.0.1");
+        cfg2.setPort(DistributedClusterIntegrationSupport.findAvailablePort());
+        cfg2.setStoreFactory(new HazelcastStoreFactory(hz2));
+        node2 = new SocketIOServer(cfg2);
+        DistributedClusterIntegrationSupport.attachDefaultRoomListeners(node2);
+        node2.start();
+        port2 = cfg2.getPort();
+    }
+
+    @AfterAll
+    public void teardown() {
+        if (node1 != null) {
+            node1.stop();
+        }
+        if (node2 != null) {
+            node2.stop();
+        }
+        if (hz1 != null) {
+            hz1.shutdown();
+        }
+        if (hz2 != null) {
+            hz2.shutdown();
+        }
+    }
+}

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaMultiChannelMemoryTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaMultiChannelMemoryTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -192,12 +193,13 @@ public class DistributedKafkaMultiChannelMemoryTest extends DistributedCommonTes
         Properties consumerProps = new Properties();
         consumerProps.put(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
-        consumerProps.put(
-                ConsumerConfig.GROUP_ID_CONFIG, "socketio4j-" + groupId);
+                // Inject a UUID to prevent offset retention between test runs
+        String uniqueGroupId = "socketio4j-" + groupId + "-" + UUID.randomUUID();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
         consumerProps.put(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProps.put(
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         consumerProps.put(
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 StringDeserializer.class);

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaMultiChannelTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaMultiChannelTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -210,12 +211,13 @@ public class DistributedKafkaMultiChannelTest extends DistributedCommonTest {
         Properties consumerProps = new Properties();
         consumerProps.put(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
-        consumerProps.put(
-                ConsumerConfig.GROUP_ID_CONFIG, "socketio4j-" + groupId);
+        // Inject a UUID to prevent offset retention between test runs
+        String uniqueGroupId = "socketio4j-" + groupId + "-" + UUID.randomUUID();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
         consumerProps.put(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProps.put(
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         consumerProps.put(
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 StringDeserializer.class);

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaSingleChannelMemoryTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaSingleChannelMemoryTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -191,12 +192,13 @@ public class DistributedKafkaSingleChannelMemoryTest extends DistributedCommonTe
         Properties consumerProps = new Properties();
         consumerProps.put(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
-        consumerProps.put(
-                ConsumerConfig.GROUP_ID_CONFIG, "socketio4j-" + groupId);
+        // Inject a UUID to prevent offset retention between test runs
+        String uniqueGroupId = "socketio4j-" + groupId + "-" + UUID.randomUUID();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
         consumerProps.put(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProps.put(
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         consumerProps.put(
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 StringDeserializer.class);

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaSingleChannelTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/DistributedKafkaSingleChannelTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -209,12 +210,13 @@ public class DistributedKafkaSingleChannelTest extends DistributedCommonTest {
         Properties consumerProps = new Properties();
         consumerProps.put(
                 ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrap);
-        consumerProps.put(
-                ConsumerConfig.GROUP_ID_CONFIG, "socketio4j-" + groupId);
+        // Inject a UUID to prevent offset retention between test runs
+        String uniqueGroupId = "socketio4j-" + groupId + "-" + UUID.randomUUID();
+        consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
         consumerProps.put(
                 ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProps.put(
-                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         consumerProps.put(
                 ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
                 StringDeserializer.class);

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3BinaryCompatibilityTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3BinaryCompatibilityTest.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2025 The Socketio4j Project
+ * Parent project : Copyright (c) 2012-2025 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.socketio4j.socketio.integration;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.socketio4j.socketio.SocketIOClient;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+import okio.ByteString;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DisplayName("Engine.IO v3 Binary Compatibility Tests")
+public class EIOv3BinaryCompatibilityTest extends AbstractSocketIOIntegrationTest {
+
+    @Test
+    @DisplayName("Should successfully decode binary event attachment from EIOv3 WebSocket client")
+    public void testEIOv3BinaryWebSocketAttachment() throws Exception {
+        final AtomicReference<byte[]> receivedData = new AtomicReference<byte[]>();
+        final AtomicReference<Boolean> handshakeReceived = new AtomicReference<Boolean>(false);
+
+        // 1. Add event listener for the binary event on the server
+        getServer().addEventListener(
+                "testBinary", byte[].class,
+                (client, data, ackRequest) -> {
+                    receivedData.set(data);
+                }
+        );
+
+        // 2. Connect OkHttp WebSocket client simulating EIOv3 (EIO=3)
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder()
+                .url("ws://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=websocket")
+                .build();
+
+        WebSocket webSocket = client.newWebSocket(request, new WebSocketListener() {
+            @Override
+            public void onMessage(WebSocket webSocket, String text) {
+                if (text.startsWith("0")) {
+                    handshakeReceived.set(true);
+                }
+            }
+
+            @Override
+            public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+                System.err.println("WebSocket failure: " + t.getMessage());
+            }
+        });
+
+        // 3. Wait for handshaking message from server
+        await().atMost(5, SECONDS)
+                .until(handshakeReceived::get);
+
+        // 4. Send connection packet to default namespace: "40"
+        webSocket.send("40");
+
+        // 5. Send event metadata packet: "451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]"
+        webSocket.send("451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]");
+
+        // 6. Send binary frame starting with byte 4 (EIOv3 MESSAGE type prefix) + data [10, 20, 30]
+        byte[] rawPayload = {4, 10, 20, 30};
+        webSocket.send(ByteString.of(rawPayload));
+
+        // 7. Verify the server successfully received and decoded the raw payload (minus prefix byte 4)
+        await().atMost(5, SECONDS)
+                .until(() -> receivedData.get() != null);
+
+        byte[] expectedData = {10, 20, 30};
+        assertNotNull(receivedData.get());
+        assertArrayEquals(expectedData, receivedData.get(), "The EIOv3 prefix byte 4 should be stripped, yielding [10, 20, 30]");
+
+        webSocket.close(1000, "Done");
+    }
+}

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3BinaryCompatibilityTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3BinaryCompatibilityTest.java
@@ -21,10 +21,10 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import com.socketio4j.socketio.SocketIOClient;
-
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
+import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
@@ -95,5 +95,125 @@ public class EIOv3BinaryCompatibilityTest extends AbstractSocketIOIntegrationTes
         assertArrayEquals(expectedData, receivedData.get(), "The EIOv3 prefix byte 4 should be stripped, yielding [10, 20, 30]");
 
         webSocket.close(1000, "Done");
+    }
+
+    @Test
+    @DisplayName("Should successfully decode binary event attachment from EIOv3 Polling client using Base64")
+    public void testEIOv3BinaryPollingBase64() throws Exception {
+        final AtomicReference<byte[]> receivedData = new AtomicReference<byte[]>();
+
+        // 1. Add event listener
+        getServer().addEventListener(
+                "testBinary", byte[].class,
+                (client, data, ackRequest) -> {
+                    receivedData.set(data);
+                }
+        );
+
+        OkHttpClient client = new OkHttpClient();
+
+        // 2. Perform handshake
+        String sid = performHandshake(client);
+
+        // 3. Namespace connect packet: "40" -> payload: "2:40"
+        sendPollingPost(client, sid, "2:40");
+
+        // 4. Send event metadata packet: "451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]" -> length 48
+        sendPollingPost(client, sid, "48:451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]");
+
+        // 5. Send base64-encoded attachment packet: "b4AQID" (base64 of [1, 2, 3]) -> length 6
+        sendPollingPost(client, sid, "6:b4AQID");
+
+        // 6. Verify server received payload
+        await().atMost(5, SECONDS)
+                .until(() -> receivedData.get() != null);
+
+        byte[] expectedData = {1, 2, 3};
+        assertNotNull(receivedData.get());
+        assertArrayEquals(expectedData, receivedData.get());
+    }
+
+    @Test
+    @DisplayName("Should successfully decode binary event attachment from EIOv3 Polling client using raw binary wrapper")
+    public void testEIOv3BinaryPollingWrapper() throws Exception {
+        final AtomicReference<byte[]> receivedData = new AtomicReference<byte[]>();
+
+        // 1. Add event listener
+        getServer().addEventListener(
+                "testBinary", byte[].class,
+                (client, data, ackRequest) -> {
+                    receivedData.set(data);
+                }
+        );
+
+        OkHttpClient client = new OkHttpClient();
+
+        // 2. Perform handshake
+        String sid = performHandshake(client);
+
+        // 3. Namespace connect packet: "40" -> payload: "2:40"
+        sendPollingPost(client, sid, "2:40");
+
+        // 4. Send event metadata packet: "451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]" -> length 48
+        sendPollingPost(client, sid, "48:451-[\"testBinary\",{\"_placeholder\":true,\"num\":0}]");
+
+        // 5. Send raw binary wrapped payload: indicator 1, length 4 (since payload [4, 10, 20, 30] has length 4), separator 255
+        // bytes: [1, 52, -1, 4, 10, 20, 30] (where 52 is ASCII '4', -1 is delimiter 255, 4 is EIOv3 MESSAGE prefix)
+        byte[] binaryBody = {1, 52, -1, 4, 10, 20, 30};
+        sendPollingPostBinary(client, sid, binaryBody);
+
+        // 6. Verify server received payload
+        await().atMost(5, SECONDS)
+                .until(() -> receivedData.get() != null);
+
+        byte[] expectedData = {10, 20, 30};
+        assertNotNull(receivedData.get());
+        assertArrayEquals(expectedData, receivedData.get());
+    }
+
+    private String performHandshake(OkHttpClient client) throws Exception {
+        Request request = new Request.Builder()
+                .url("http://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=polling")
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            String body = response.body().string();
+            int jsonStartIndex = body.indexOf('{');
+            if (jsonStartIndex == -1) {
+                throw new IllegalStateException("Invalid handshake response format: " + body);
+            }
+            String json = body.substring(jsonStartIndex);
+            java.util.regex.Pattern pattern = java.util.regex.Pattern.compile("\"sid\":\"([^\"]+)\"");
+            java.util.regex.Matcher matcher = pattern.matcher(json);
+            if (matcher.find()) {
+                return matcher.group(1);
+            }
+            throw new IllegalStateException("sid not found in handshake response: " + body);
+        }
+    }
+
+    private void sendPollingPost(OkHttpClient client, String sid, String textBody) throws Exception {
+        RequestBody requestBody = RequestBody.create(MediaType.parse("text/plain; charset=utf-8"), textBody);
+        Request request = new Request.Builder()
+                .url("http://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=polling&sid=" + sid)
+                .post(requestBody)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("POST failed: " + response.code() + " " + response.body().string());
+            }
+        }
+    }
+
+    private void sendPollingPostBinary(OkHttpClient client, String sid, byte[] binaryBody) throws Exception {
+        RequestBody requestBody = RequestBody.create(MediaType.parse("application/octet-stream"), binaryBody);
+        Request request = new Request.Builder()
+                .url("http://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=polling&sid=" + sid)
+                .post(requestBody)
+                .build();
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IllegalStateException("POST failed: " + response.code() + " " + response.body().string());
+            }
+        }
     }
 }

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3FeaturesTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/integration/EIOv3FeaturesTest.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) 2025 The Socketio4j Project
+ * Parent project : Copyright (c) 2012-2025 Nikita Koksharov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.socketio4j.socketio.integration;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.socketio4j.socketio.SocketIOClient;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import okhttp3.WebSocket;
+import okhttp3.WebSocketListener;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("Engine.IO v3 Generic Features Integration Tests")
+public class EIOv3FeaturesTest extends AbstractSocketIOIntegrationTest {
+
+    @Test
+    @DisplayName("Should successfully handle connection, disconnection, text messaging, room join, room leave, and broadcasting for EIOv3 clients")
+    public void testEIOv3GenericFeatures() throws Exception {
+        final AtomicInteger serverConnections = new AtomicInteger(0);
+        final AtomicInteger serverDisconnections = new AtomicInteger(0);
+        final AtomicReference<String> receivedTextVal = new AtomicReference<String>();
+        final AtomicReference<UUID> client1SessionId = new AtomicReference<UUID>();
+        final AtomicReference<UUID> client2SessionId = new AtomicReference<UUID>();
+        
+        final List<String> client1Messages = new CopyOnWriteArrayList<String>();
+        final List<String> client2Messages = new CopyOnWriteArrayList<String>();
+
+        // 1. Configure server listeners
+        getServer().addConnectListener(client -> {
+            int currentConn = serverConnections.incrementAndGet();
+            client.joinRoom("testRoom");
+            if (currentConn == 1) {
+                client1SessionId.set(client.getSessionId());
+            } else if (currentConn == 2) {
+                client2SessionId.set(client.getSessionId());
+            }
+        });
+
+        getServer().addDisconnectListener(client -> {
+            serverDisconnections.incrementAndGet();
+        });
+
+        getServer().addEventListener("testText", String.class, (client, data, ackRequest) -> {
+            receivedTextVal.set(data);
+        });
+
+        // 2. Connect Client 1 using WebSocket EIO=3
+        OkHttpClient httpClient = new OkHttpClient();
+        
+        Request request1 = new Request.Builder()
+                .url("ws://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=websocket")
+                .build();
+
+        WebSocket webSocket1 = httpClient.newWebSocket(request1, new WebSocketListener() {
+            @Override
+            public void onMessage(WebSocket webSocket, String text) {
+                client1Messages.add(text);
+            }
+        });
+
+        // Wait for Client 1 connection on server
+        await().atMost(5, SECONDS).until(() -> serverConnections.get() == 1);
+        assertNotNull(client1SessionId.get());
+
+        // 3. Connect Client 2 using WebSocket EIO=3
+        Request request2 = new Request.Builder()
+                .url("ws://" + getServerHost() + ":" + getServerPort() + "/socket.io/?EIO=3&transport=websocket")
+                .build();
+
+        WebSocket webSocket2 = httpClient.newWebSocket(request2, new WebSocketListener() {
+            @Override
+            public void onMessage(WebSocket webSocket, String text) {
+                client2Messages.add(text);
+            }
+        });
+
+        // Wait for Client 2 connection on server
+        await().atMost(5, SECONDS).until(() -> serverConnections.get() == 2);
+        assertNotNull(client2SessionId.get());
+
+        // Both clients need to send namespace connect packet: "40"
+        webSocket1.send("40");
+        webSocket2.send("40");
+
+        // 4. Test Text Messaging (client to server)
+        // Send: "42[\"testText\",\"hello from client 1\"]"
+        webSocket1.send("42[\"testText\",\"hello from client 1\"]");
+
+        await().atMost(5, SECONDS).until(() -> receivedTextVal.get() != null);
+        assertEquals("hello from client 1", receivedTextVal.get());
+
+        // 5. Test Broadcasting to Room "testRoom" (which both joined)
+        getServer().getRoomOperations("testRoom").sendEvent("roomBroadcast", "welcome");
+
+        // Both clients should receive: "42[\"roomBroadcast\",\"welcome\"]"
+        await().atMost(5, SECONDS).until(() -> 
+            client1Messages.stream().anyMatch(msg -> msg.contains("roomBroadcast")) &&
+            client2Messages.stream().anyMatch(msg -> msg.contains("roomBroadcast"))
+        );
+
+        // 6. Test Room Leave (Client 2 leaves room)
+        SocketIOClient sClient2 = getServer().getClient(client2SessionId.get());
+        assertNotNull(sClient2);
+        sClient2.leaveRoom("testRoom");
+
+        // Send second broadcast to "testRoom"
+        getServer().getRoomOperations("testRoom").sendEvent("roomBroadcast2", "hello again");
+
+        // Client 1 should receive it, Client 2 should NOT
+        await().atMost(5, SECONDS).until(() -> 
+            client1Messages.stream().anyMatch(msg -> msg.contains("roomBroadcast2"))
+        );
+        
+        // Wait a short duration to ensure Client 2 did not receive the second broadcast
+        Thread.sleep(500);
+        assertTrue(client2Messages.stream().noneMatch(msg -> msg.contains("roomBroadcast2")));
+
+        // 7. Test Disconnection
+        webSocket1.close(1000, "Done");
+        webSocket2.close(1000, "Done");
+
+        await().atMost(5, SECONDS).until(() -> serverDisconnections.get() == 2);
+    }
+}

--- a/netty-socketio-core/src/test/java/com/socketio4j/socketio/protocol/PacketDecoderTest.java
+++ b/netty-socketio-core/src/test/java/com/socketio4j/socketio/protocol/PacketDecoderTest.java
@@ -883,4 +883,159 @@ public class PacketDecoderTest extends BaseProtocolTest {
 
         buffer.release();
     }
+
+    @Test
+    void testDecodeEIOv3BinaryAttachmentWebSocket() throws IOException {
+        // EIOv3 client
+        when(clientHead.getEngineIOVersion()).thenReturn(EngineIOVersion.V3);
+
+        java.util.concurrent.atomic.AtomicReference<Packet> lastBinaryPacket = new java.util.concurrent.atomic.AtomicReference<>();
+        org.mockito.Mockito.doAnswer(invocation -> {
+            lastBinaryPacket.set(invocation.getArgument(0));
+            return null;
+        }).when(clientHead).setLastBinaryPacket(any());
+        when(clientHead.getLastBinaryPacket()).thenAnswer(invocation -> lastBinaryPacket.get());
+
+        // 1. Decode text frame first
+        ByteBuf textBuffer = Unpooled.copiedBuffer("451-[\"hello\",{\"_placeholder\":true,\"num\":0}]", CharsetUtil.UTF_8);
+        
+        Event mockEvent = new Event("hello", Arrays.asList(new HashMap<>()));
+        when(jsonSupport.readValue(eq(""), any(), eq(Event.class))).thenReturn(mockEvent);
+
+        Packet firstPacket = decoder.decodePackets(textBuffer, clientHead);
+        assertNotNull(firstPacket);
+        assertEquals(PacketType.MESSAGE, firstPacket.getType());
+        assertEquals(PacketType.BINARY_EVENT, firstPacket.getSubType());
+        assertTrue(firstPacket.hasAttachments());
+        assertEquals(firstPacket, lastBinaryPacket.get());
+
+        // 2. Decode binary attachment frame (starts with byte 4)
+        byte[] binaryDataWithPrefix = {4, 1, 2, 3}; // 4 prefix, then [1, 2, 3]
+        ByteBuf binaryBuffer = Unpooled.copiedBuffer(binaryDataWithPrefix);
+
+        Packet resultPacket = decoder.decodePackets(binaryBuffer, clientHead);
+        assertNotNull(resultPacket);
+        
+        // The attachment stored should be base64-encoded [1, 2, 3] (which is "AQID")
+        assertEquals(1, resultPacket.getAttachments().size());
+        ByteBuf attachment = resultPacket.getAttachments().get(0);
+        assertEquals("AQID", attachment.toString(CharsetUtil.UTF_8));
+
+        textBuffer.release();
+        binaryBuffer.release();
+    }
+
+    @Test
+    void testDecodeEIOv3BinaryAttachmentBase64() throws IOException {
+        // EIOv3 client
+        when(clientHead.getEngineIOVersion()).thenReturn(EngineIOVersion.V3);
+
+        java.util.concurrent.atomic.AtomicReference<Packet> lastBinaryPacket = new java.util.concurrent.atomic.AtomicReference<>();
+        org.mockito.Mockito.doAnswer(invocation -> {
+            lastBinaryPacket.set(invocation.getArgument(0));
+            return null;
+        }).when(clientHead).setLastBinaryPacket(any());
+        when(clientHead.getLastBinaryPacket()).thenAnswer(invocation -> lastBinaryPacket.get());
+
+        // 1. Decode text frame first
+        ByteBuf textBuffer = Unpooled.copiedBuffer("451-[\"hello\",{\"_placeholder\":true,\"num\":0}]", CharsetUtil.UTF_8);
+        
+        Event mockEvent = new Event("hello", Arrays.asList(new HashMap<>()));
+        when(jsonSupport.readValue(eq(""), any(), eq(Event.class))).thenReturn(mockEvent);
+
+        Packet firstPacket = decoder.decodePackets(textBuffer, clientHead);
+        assertNotNull(firstPacket);
+        assertTrue(firstPacket.hasAttachments());
+
+        // 2. Decode base64 attachment frame (starts with "b4")
+        ByteBuf binaryBuffer = Unpooled.copiedBuffer("b4AQID", CharsetUtil.UTF_8); // "b4" + "AQID"
+
+        Packet resultPacket = decoder.decodePackets(binaryBuffer, clientHead);
+        assertNotNull(resultPacket);
+        
+        assertEquals(1, resultPacket.getAttachments().size());
+        ByteBuf attachment = resultPacket.getAttachments().get(0);
+        assertEquals("AQID", attachment.toString(CharsetUtil.UTF_8));
+
+        textBuffer.release();
+        binaryBuffer.release();
+    }
+
+    @Test
+    void testDecodeEIOv3BinaryAttachmentPollingWrapper() throws IOException {
+        // EIOv3 client
+        when(clientHead.getEngineIOVersion()).thenReturn(EngineIOVersion.V3);
+
+        java.util.concurrent.atomic.AtomicReference<Packet> lastBinaryPacket = new java.util.concurrent.atomic.AtomicReference<>();
+        org.mockito.Mockito.doAnswer(invocation -> {
+            lastBinaryPacket.set(invocation.getArgument(0));
+            return null;
+        }).when(clientHead).setLastBinaryPacket(any());
+        when(clientHead.getLastBinaryPacket()).thenAnswer(invocation -> lastBinaryPacket.get());
+
+        // 1. Decode text frame first
+        ByteBuf textBuffer = Unpooled.copiedBuffer("451-[\"hello\",{\"_placeholder\":true,\"num\":0}]", CharsetUtil.UTF_8);
+        
+        Event mockEvent = new Event("hello", Arrays.asList(new HashMap<>()));
+        when(jsonSupport.readValue(eq(""), any(), eq(Event.class))).thenReturn(mockEvent);
+
+        Packet firstPacket = decoder.decodePackets(textBuffer, clientHead);
+        assertNotNull(firstPacket);
+        assertTrue(firstPacket.hasAttachments());
+
+        // 2. Decode polling wrapper frame: 
+        // byte 1 (binary indicator), length (4 bytes of ASCII: '4'), byte -1 (255 indicator), 
+        // then prefix byte 4, then data [1, 2, 3] -> wrapper payload has length 4.
+        byte[] pollingPayload = {1, (byte)'4', (byte)-1, 4, 1, 2, 3};
+        ByteBuf binaryBuffer = Unpooled.copiedBuffer(pollingPayload);
+
+        Packet resultPacket = decoder.decodePackets(binaryBuffer, clientHead);
+        assertNotNull(resultPacket);
+        
+        assertEquals(1, resultPacket.getAttachments().size());
+        ByteBuf attachment = resultPacket.getAttachments().get(0);
+        assertEquals("AQID", attachment.toString(CharsetUtil.UTF_8));
+
+        textBuffer.release();
+        binaryBuffer.release();
+    }
+
+    @Test
+    void testDecodeEIOv4BinaryAttachmentNoStrip() throws IOException {
+        // EIOv4 client (default)
+        when(clientHead.getEngineIOVersion()).thenReturn(EngineIOVersion.V4);
+
+        java.util.concurrent.atomic.AtomicReference<Packet> lastBinaryPacket = new java.util.concurrent.atomic.AtomicReference<>();
+        org.mockito.Mockito.doAnswer(invocation -> {
+            lastBinaryPacket.set(invocation.getArgument(0));
+            return null;
+        }).when(clientHead).setLastBinaryPacket(any());
+        when(clientHead.getLastBinaryPacket()).thenAnswer(invocation -> lastBinaryPacket.get());
+
+        // 1. Decode text frame first
+        ByteBuf textBuffer = Unpooled.copiedBuffer("451-[\"hello\",{\"_placeholder\":true,\"num\":0}]", CharsetUtil.UTF_8);
+        
+        Event mockEvent = new Event("hello", Arrays.asList(new HashMap<>()));
+        when(jsonSupport.readValue(eq(""), any(), eq(Event.class))).thenReturn(mockEvent);
+
+        Packet firstPacket = decoder.decodePackets(textBuffer, clientHead);
+        assertNotNull(firstPacket);
+        assertTrue(firstPacket.hasAttachments());
+
+        // 2. Decode binary attachment frame starting with byte 4.
+        // For EIOv4, this byte 4 is NOT a prefix and must be preserved.
+        byte[] binaryData = {4, 1, 2, 3}; 
+        ByteBuf binaryBuffer = Unpooled.copiedBuffer(binaryData);
+
+        Packet resultPacket = decoder.decodePackets(binaryBuffer, clientHead);
+        assertNotNull(resultPacket);
+        
+        // The attachment stored should be base64-encoded [4, 1, 2, 3] (which is "BAECAw==")
+        assertEquals(1, resultPacket.getAttachments().size());
+        ByteBuf attachment = resultPacket.getAttachments().get(0);
+        assertEquals("BAECAw==", attachment.toString(CharsetUtil.UTF_8));
+
+        textBuffer.release();
+        binaryBuffer.release();
+    }
 }

--- a/netty-socketio-examples/netty-socketio-core-example/pom.xml
+++ b/netty-socketio-examples/netty-socketio-core-example/pom.xml
@@ -17,8 +17,8 @@
     <properties>
         <micrometer.version>1.16.1</micrometer.version>
         <hll.version>1.6.0</hll.version>
-        <netty.version>4.2.9.Final</netty.version>
-        <jackson.version>2.21.1</jackson.version>
+        <netty.version>4.2.16.Final</netty.version>
+
     </properties>
 
     <dependencyManagement>
@@ -29,6 +29,19 @@
                 <version>${micrometer.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+
+                <groupId>com.fasterxml.jackson</groupId>
+
+                <artifactId>jackson-bom</artifactId>
+
+                <version>2.22.0</version>
+
+                <type>pom</type>
+
+                <scope>import</scope>
+
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -55,7 +68,7 @@
         <dependency>
             <groupId>com.socketio4j</groupId>
             <artifactId>netty-socketio-core</artifactId>
-            <version>4.0.2-SNAPSHOT</version>
+            <version>4.0.1</version>
         </dependency>
 
         <!-- Netty -->
@@ -69,19 +82,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
+
         </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.20</version>
+
         </dependency>
 
         <!-- Logging -->

--- a/netty-socketio-examples/netty-socketio-core-example/pom.xml
+++ b/netty-socketio-examples/netty-socketio-core-example/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.socketio4j</groupId>
             <artifactId>netty-socketio-core</artifactId>
-            <version>4.0.1</version>
+            <version>4.0.2-SNAPSHOT</version>
         </dependency>
 
         <!-- Netty -->
@@ -121,6 +121,18 @@
             <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
             <version>1.10.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>5.2.5</version>
         </dependency>
 
     </dependencies>

--- a/netty-socketio-examples/netty-socketio-core-example/src/main/java/com/socketio4j/example/core/CoreExampleMain.java
+++ b/netty-socketio-examples/netty-socketio-core-example/src/main/java/com/socketio4j/example/core/CoreExampleMain.java
@@ -68,15 +68,11 @@ public final class CoreExampleMain {
             server.getRoomOperations(room)
                     .sendEvent("pong", "pong: " + data);
         });
-        server.addEventListener("hi", String.class, (client, data, ack) -> {
-            String room = client.getSessionId().toString();
-            server.getRoomOperations(room)
-                    .sendEvent("pong", "pong: " + data);
+        server.addEventListener("hi", byte[].class, (client, data, ack) -> {
+            client.sendEvent("hello", "pong: " + data);
         });
-        server.getNamespace("/example").addEventListener("hi", String.class, (client, data, ack) -> {
-            String room = client.getSessionId().toString();
-            server.getRoomOperations(room)
-                    .sendEvent("pong", "pong: " + data);
+        server.getNamespace("/example").addEventListener("hi", byte[].class, (client, data, ack) -> {
+            client.sendEvent("hello", "pong: " + data);
         });
 
         server.start();

--- a/netty-socketio-examples/netty-socketio-core-example/src/main/java/com/socketio4j/example/core/CoreExampleMain.java
+++ b/netty-socketio-examples/netty-socketio-core-example/src/main/java/com/socketio4j/example/core/CoreExampleMain.java
@@ -1,94 +1,286 @@
 package com.socketio4j.example.core;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
 import com.socketio4j.socketio.AckMode;
 import com.socketio4j.socketio.Configuration;
 import com.socketio4j.socketio.SocketIOServer;
-
-
-import java.util.UUID;
-
-import com.socketio4j.socketio.metrics.MicrometerMetricsFactory;
-import com.socketio4j.socketio.metrics.MicrometerSocketIOMetrics;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.registry.otlp.OtlpConfig;
-import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import com.socketio4j.socketio.store.hazelcast.HazelcastStoreFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public final class CoreExampleMain {
 
     private static final Logger log =
             LoggerFactory.getLogger(CoreExampleMain.class);
 
     public static void main(String[] args) {
-        Configuration config = new Configuration();
-        config.setPort(4000);
-        config.setMetricsEnabled(true);
-        config.setAckMode(AckMode.AUTO_SUCCESS_ONLY);
-        config.setMicrometerHistogramEnabled(true);
-        MicrometerSocketIOMetrics mic = MicrometerMetricsFactory.using(new OtlpMeterRegistry(OtlpConfig.DEFAULT, Clock.SYSTEM), config.isMicrometerHistogramEnabled());
-        config.setMetrics(mic);
-        SocketIOServer server = new SocketIOServer(config);
-        server.addNamespace("/example");
-        /*
-        MicrometerSocketIOMetrics micrometerSocketIOMetrics = (MicrometerSocketIOMetrics) config.getMetrics();
-        MetricsHttpServer metricsServer =
-                new MetricsHttpServer(
-                        micrometerSocketIOMetrics.prometheus(),
-                        "0.0.0.0",
-                        8080,
-                        "/metrics"
-                );
+        log.info("Starting Clustered Netty Socket.IO Example Servers...");
 
-        //metricsServer.start();
-*/
+
+
+        // 1. Configure Hazelcast for Server 1
+        Config hzConfig1 = new Config();
+        hzConfig1.setInstanceName("hz1");
+        hzConfig1.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        hzConfig1.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+        hzConfig1.getNetworkConfig().getInterfaces().setEnabled(true).addInterface("127.0.0.1");
+
+        // 2. Configure Hazelcast for Server 2
+        Config hzConfig2 = new Config();
+        hzConfig2.setInstanceName("hz2");
+        hzConfig2.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
+        hzConfig2.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1");
+        hzConfig2.getNetworkConfig().getInterfaces().setEnabled(true).addInterface("127.0.0.1");
+
+        HazelcastInstance hz1 = Hazelcast.newHazelcastInstance(hzConfig1);
+        HazelcastInstance hz2 = Hazelcast.newHazelcastInstance(hzConfig2);
+
+        // ----------------------------------------------------------------
+
+        // 3. Configure Server 1 on Port 4000
+        Configuration config1 = new Configuration();
+        config1.setHostname("127.0.0.1");
+        config1.setPort(4000);
+        config1.setMetricsEnabled(false);
+        config1.setAckMode(AckMode.AUTO_SUCCESS_ONLY);
+        config1.setStoreFactory(new HazelcastStoreFactory(hz1));
+        SocketIOServer server1 = new SocketIOServer(config1);
+        setupServer(server1);
+
+        // 4. Configure Server 2 on Port 4001
+        Configuration config2 = new Configuration();
+        config2.setHostname("127.0.0.1");
+        config2.setPort(4001);
+        config2.setMetricsEnabled(false);
+        config2.setAckMode(AckMode.AUTO_SUCCESS_ONLY);
+        config2.setStoreFactory(new HazelcastStoreFactory(hz2));
+        SocketIOServer server2 = new SocketIOServer(config2);
+        setupServer(server2);
+
+        server1.start();
+        server2.start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                log.info("Shutting down servers and cluster...");
+                server1.stop();
+                server2.stop();
+                hz1.shutdown();
+                hz2.shutdown();
+            }
+        });
+
+        log.info("Server 1 listening @ http://localhost:4000");
+        log.info("Server 2 listening @ http://localhost:4001");
+    }
+
+    private static void setupServer(SocketIOServer server) {
+        server.addNamespace("/example");
+
+        // ── /example namespace ───────────────────────────────────────────────
+
         server.getNamespace("/example").addConnectListener(client -> {
-            String sessionRoom = client.getSessionId().toString(); // automatically exists
+            String sessionRoom = client.getSessionId().toString();
+            client.joinRoom(sessionRoom);
             client.joinRoom("room1");
             client.joinRoom("room2");
-            //client.leaveRoom("room1");
-            log.info("connected: {} client : {} {}", sessionRoom, client, client.getSessionId());
-            log.info("cli {}", server.getNamespace("").getClient(UUID.fromString(sessionRoom)));
-            // send private welcome
-            server.getRoomOperations(sessionRoom)
-                    .sendEvent("welcome", "your private room is " + sessionRoom);
+            log.info("[/example] connected: sessionId={}", client.getSessionId());
+            // Send welcome directly to the client — avoids a race between
+            // joinRoom and getRoomOperations which can lose the event for EIOv4.
+            client.sendEvent("welcome", "your private room is " + sessionRoom);
         });
+
+        server.getNamespace("/example").addDisconnectListener(client ->
+            log.info("[/example] disconnected: sessionId={}", client.getSessionId())
+        );
+
+        // Binary echo on /example — echo back the exact bytes received
+        server.getNamespace("/example").addEventListener("hi", byte[].class, (client, data, ack) -> {
+            log.debug("[/example] hi from {}: {} byte(s)", client.getSessionId(), data.length);
+            client.sendEvent("hello", data);
+        });
+
+        // ── Default namespace / ──────────────────────────────────────────────
+
         server.addConnectListener(client -> {
-            String sessionRoom = client.getSessionId().toString(); // automatically exists
+            String sessionRoom = client.getSessionId().toString();
+            client.joinRoom(sessionRoom);
             client.joinRoom("room1");
-            //client.leaveRoom("room1");
-            log.info("connected: {} {}", sessionRoom, client);
-            log.info("client {}", server.getNamespace("").getClient(UUID.fromString(sessionRoom)));
-            // send private welcome
-            server.getRoomOperations(sessionRoom)
-                    .sendEvent("welcome", "your private room is " + sessionRoom);
+            log.info("[/] connected: sessionId={}", client.getSessionId());
+            // Send welcome directly to the client — avoids a race between
+            // joinRoom and getRoomOperations which can lose the event for EIOv4.
+            client.sendEvent("welcome", "your private room is " + sessionRoom);
         });
+
+        server.addDisconnectListener(client ->
+            log.info("[/] disconnected: sessionId={}", client.getSessionId())
+        );
+
+        // ── Text ping-pong (private reply to sender) ─────────────────────────
 
         server.addEventListener("ping-me", String.class, (client, data, ack) -> {
             String room = client.getSessionId().toString();
-            server.getRoomOperations(room)
-                    .sendEvent("pong", "pong: " + data);
+            log.debug("[/] ping-me from {}: {}", client.getSessionId(), data);
+            server.getRoomOperations(room).sendEvent("pong", "pong: " + data);
         });
+
+        // ── Binary echo on / — echo back exact bytes ─────────────────────────
+
         server.addEventListener("hi", byte[].class, (client, data, ack) -> {
-            client.sendEvent("hello", "pong: " + data);
-        });
-        server.getNamespace("/example").addEventListener("hi", byte[].class, (client, data, ack) -> {
-            client.sendEvent("hello", "pong: " + data);
+            log.debug("[/] hi from {}: {} byte(s)", client.getSessionId(), data.length);
+            client.sendEvent("hello", data);
         });
 
-        server.start();
+        // ── Distributed broadcast: text to room1 ─────────────────────────────
 
-        Runtime runtime = Runtime.getRuntime();
+        server.addEventListener("broadcast-msg", String.class, (client, data, ack) -> {
+            log.info("[/] broadcast-msg from {}: {}", client.getSessionId(), data);
+            server.getRoomOperations("room1").sendEvent("room-event", data);
+        });
 
-        // Register an anonymous inner class that extends Thread as a shutdown hook
-        runtime.addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                server.stop();
-                mic.close();
-                //metricsServer.stop();
+        // ── Distributed broadcast: binary to room1 ───────────────────────────
+
+        server.addEventListener("broadcast-binary", byte[].class, (client, data, ack) -> {
+            log.info("[/] broadcast-binary from {}: {} byte(s)", client.getSessionId(), data.length);
+            server.getRoomOperations("room1").sendEvent("room-binary-event", data);
+        });
+
+        // ── Custom room management ────────────────────────────────────────────
+
+        /**
+         * join-custom-room   payload: room name
+         * Server joins client to room and sends back 'joined' confirmation.
+         * Compatible with test-client.js "join-custom-room" flow.
+         */
+        server.addEventListener("join-custom-room", String.class, (client, data, ack) -> {
+            if (data == null || data.isBlank()) {
+                log.warn("[/] join-custom-room: empty room name from {}", client.getSessionId());
+                return;
+            }
+            log.info("[/] join-custom-room: {} → {}", client.getSessionId(), data);
+            client.joinRoom(data);
+            client.sendEvent("joined", data);
+        });
+
+        /**
+         * join-room          payload: room name
+         * Alias used by DistributedCommonTest — sends back 'join-ok' confirmation.
+         */
+        server.addEventListener("join-room", String.class, (client, data, ack) -> {
+            if (data == null || data.isBlank()) {
+                log.warn("[/] join-room: empty room name from {}", client.getSessionId());
+                return;
+            }
+            log.info("[/] join-room: {} → {}", client.getSessionId(), data);
+            client.joinRoom(data);
+            client.sendEvent("join-ok", "OK");
+        });
+
+        /**
+         * leave-custom-room  payload: room name
+         * Server removes client from room and sends back 'left' confirmation.
+         */
+        server.addEventListener("leave-custom-room", String.class, (client, data, ack) -> {
+            if (data == null || data.isBlank()) {
+                log.warn("[/] leave-custom-room: empty room name from {}", client.getSessionId());
+                return;
+            }
+            log.info("[/] leave-custom-room: {} ← {}", client.getSessionId(), data);
+            client.leaveRoom(data);
+            client.sendEvent("left", data);
+        });
+
+        /**
+         * leave-room         payload: room name
+         * Alias used by DistributedCommonTest — sends back 'leave-ok' confirmation.
+         */
+        server.addEventListener("leave-room", String.class, (client, data, ack) -> {
+            if (data == null || data.isBlank()) {
+                log.warn("[/] leave-room: empty room name from {}", client.getSessionId());
+                return;
+            }
+            log.info("[/] leave-room: {} ← {}", client.getSessionId(), data);
+            client.leaveRoom(data);
+            client.sendEvent("leave-ok", "OK");
+        });
+
+        /**
+         * get-my-rooms  payload: ignored
+         * Acks with a JSON array of the rooms the calling client is currently in.
+         * Used by DistributedCommonTest.testConnectAndJoinDifferentRoomTest.
+         */
+        server.addEventListener("get-my-rooms", String.class, (client, data, ack) -> {
+            List<String> rooms = new ArrayList<>(client.getAllRooms());
+            log.info("[/] get-my-rooms for {}: {}", client.getSessionId(), rooms);
+            if (ack != null && ack.isAckRequested()) {
+                ack.sendAckData(rooms);
             }
         });
-        log.info("Shutdown Hook Attached.");
-        log.info("Socket.IO listening @ http://localhost: {}", config.getPort());
+
+        // ── Custom room broadcast ─────────────────────────────────────────────
+
+        /**
+         * broadcast-custom-room  payload: "<roomName>:<message>"
+         * Broadcasts <message> to all members of <roomName>.
+         * Guards against malformed payloads (no ':' separator).
+         */
+        server.addEventListener("broadcast-custom-room", String.class, (client, data, ack) -> {
+            if (data == null || !data.contains(":")) {
+                log.warn("[/] broadcast-custom-room: malformed payload from {}: '{}'",
+                        client.getSessionId(), data);
+                return;
+            }
+            String[] parts   = data.split(":", 2);
+            String roomName  = parts[0];
+            String message   = parts[1];
+            log.info("[/] broadcast-custom-room: {} → room '{}': {}",
+                    client.getSessionId(), roomName, message);
+            server.getRoomOperations(roomName).sendEvent("custom-room-event", message);
+        });
+
+        // ── Exclude-sender broadcast ──────────────────────────────────────────
+
+        server.addEventListener("broadcast-exclude-sender", String.class, (client, data, ack) -> {
+            log.info("[/] broadcast-exclude-sender from {}: {}", client.getSessionId(), data);
+            server.getRoomOperations("room1").sendEvent("exclude-event", client, data);
+        });
+
+        // ── JSON round-trip ───────────────────────────────────────────────────
+
+        server.addEventListener("json-event", CustomMessage.class, (client, data, ack) -> {
+            log.info("[/] json-event from {}: id={} message={} ts={}",
+                    client.getSessionId(), data.getId(), data.getMessage(), data.getTimestamp());
+            server.getRoomOperations("room1").sendEvent("custom-json-response", data);
+        });
+    }
+
+    public static class CustomMessage implements java.io.Serializable {
+        private static final long serialVersionUID = 1L;
+        private int id;
+        private String message;
+        private long timestamp;
+
+        public CustomMessage() {}
+
+        public CustomMessage(int id, String message, long timestamp) {
+            this.id = id;
+            this.message = message;
+            this.timestamp = timestamp;
+        }
+
+        public int getId() { return id; }
+        public void setId(int id) { this.id = id; }
+
+        public String getMessage() { return message; }
+        public void setMessage(String message) { this.message = message; }
+
+        public long getTimestamp() { return timestamp; }
+        public void setTimestamp(long timestamp) { this.timestamp = timestamp; }
     }
 }


### PR DESCRIPTION
Add robust Engine.IO v3/v4 binary attachment handling in PacketDecoder: strip EIOv3 polling wrappers and 'b4' / MESSAGE (0x04) prefixes while preserving raw v4 frames; base64-encode attachments appropriately. Add integration test EIOv3BinaryCompatibilityTest and extend PacketDecoderTest with unit cases for v3 (raw, base64, polling wrapper) and v4 behavior. Update example project POM (Netty version bump, import jackson-bom) and adjust CoreExampleMain to use byte[] event handlers and send responses accordingly.

## Description

Brief description of the changes in this PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #(issue number)

## Changes Made

- 
- 
- 

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [ ] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

Any additional information, screenshots, or context that reviewers should know.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reworked the clustered core example to run multiple Hazelcast-backed servers with enhanced room/event handling and a `byte[]` → direct reply flow.
* **Bug Fixes**
  * Improved Engine.IO v3/v4 binary attachment compatibility for both WebSocket and polling, including correct attachment framing/prefix handling.
  * Ensured outgoing packets respect the target client’s Engine.IO version during dispatch.
* **Tests**
  * Expanded Engine.IO v3 binary and feature integration coverage, plus more deterministic multi-node/in-process cluster tests.
  * Improved distributed Kafka test isolation by using per-run consumer groups and earlier offset reset.
* **Chores**
  * Refreshed example dependencies and centralized Jackson versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->