### PR TITLE
Allow specific java.util subtypes in PT validator

### DIFF
--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageDeserializer.java
@@ -41,11 +41,16 @@ public final class EventMessageDeserializer
     static {
         PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType("com.socketio4j.socketio")
-                .allowIfBaseType("java.util")
+
+                .allowIfSubType("java.util.ArrayList")
+                .allowIfSubType("java.util.HashMap")
+                .allowIfSubType("java.util.LinkedHashMap")
+
                 .allowIfSubType("java.util.Arrays$")
+                .allowIfSubType("java.util.Collections$")
+                .allowIfSubType("java.util.ImmutableCollections$")
+
                 .allowIfSubTypeIsArray()
-                .allowIfSubType("java.time")
-                .allowIfSubType("java.math")
                 .build();
 
         MAPPER = JsonMapper.builder()

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/kafka/serialization/EventMessageSerializer.java
@@ -42,11 +42,16 @@ public final class EventMessageSerializer
     static {
         PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType("com.socketio4j.socketio")
-                .allowIfBaseType("java.util")
+
+                .allowIfSubType("java.util.ArrayList")
+                .allowIfSubType("java.util.HashMap")
+                .allowIfSubType("java.util.LinkedHashMap")
+
                 .allowIfSubType("java.util.Arrays$")
+                .allowIfSubType("java.util.Collections$")
+                .allowIfSubType("java.util.ImmutableCollections$")
+
                 .allowIfSubTypeIsArray()
-                .allowIfSubType("java.time")
-                .allowIfSubType("java.math")
                 .build();
 
         MAPPER = JsonMapper.builder()

--- a/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
+++ b/netty-socketio-core/src/main/java/com/socketio4j/socketio/store/nats_pubsub/EventMessageCodec.java
@@ -36,11 +36,16 @@ public final class EventMessageCodec {
     static {
         PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType("com.socketio4j.socketio")
-                .allowIfBaseType("java.util")
+
+                .allowIfSubType("java.util.ArrayList")
+                .allowIfSubType("java.util.HashMap")
+                .allowIfSubType("java.util.LinkedHashMap")
+
                 .allowIfSubType("java.util.Arrays$")
+                .allowIfSubType("java.util.Collections$")
+                .allowIfSubType("java.util.ImmutableCollections$")
+
                 .allowIfSubTypeIsArray()
-                .allowIfSubType("java.time")
-                .allowIfSubType("java.math")
                 .build();
 
         MAPPER = JsonMapper.builder()


### PR DESCRIPTION
Tighten Jackson BasicPolymorphicTypeValidator to explicitly allow known java.util implementations (ArrayList, HashMap, LinkedHashMap, Arrays$, Collections$, ImmutableCollections$) instead of allowing the broad java.util base type. Removed permissive java.time and java.math subtype allowances. Changes applied to EventMessageDeserializer, EventMessageSerializer, and EventMessageCodec to reduce risk from polymorphic deserialization.

## Description

Brief description of the changes in this PR.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Build/tooling changes

## Related Issue

Closes #(issue number)

## Changes Made

- 
- 
- 

## Testing

- [ ] All existing tests pass
- [ ] New tests added for new functionality
- [ ] Tests pass locally with `mvn test`
- [ ] Integration tests pass (if applicable)

## Checklist

- [ ] Code follows project coding standards
- [ ] Self-review completed
- [ ] Code is commented where necessary
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow conventional format
- [ ] No merge conflicts
- [ ] All CI checks pass

## Additional Notes

Any additional information, screenshots, or context that reviewers should know.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of serialized event data by restricting polymorphic type processing to explicitly supported collection and map types.
  - Continued support for arrays and commonly used collection implementations.
  - Preserved existing behavior for empty or invalid data, including graceful failure and error logging.
  - Updated serialization and deserialization paths consistently across Kafka and NATS-based messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->